### PR TITLE
Adding ffscreencast for easy screenrecording (Linux & OSX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 * [AutoScreenshotUploader](https://github.com/yask123/AutoScreenshotUploader)- Instantly capture and upload screenshot to [imgur](https://imgur.com)
 
+* [ffscreencast](https://github.com/cytopia/ffscreencast)- ffmpeg screencast with video overlay and multi monitor support
+
 * [idea](https://github.com/IonicaBizau/idea)- A lightweight CLI tool and module for keeping ideas in a safe place quick and easy.
 
 * [geeknote](https://github.com/VitaliyRodnenko/geeknote)- Console client for Evernote.


### PR DESCRIPTION
This tool allows you to do simple and complex screencasts.

* Chosse monitor (if multiple monitors are connected)
* Sound and camera overlay are optional
* Possibility to read out camera resolution (OSX & Linux)
* Possibility to just list the corresponding ffmpeg command (dry-run)