### PR TITLE
Add: otp-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -368,6 +368,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [task-spooler](http://vicerveza.homeunix.net/~viric/soft/ts) - Queue jobs for linear execution.
 - [undollar](https://github.com/ImFeelingDucky/undollar) - Strip the '$' preceding copy-pasted terminal commands.
 - [pipe_exec](https://github.com/koraa/pipe_exec) - Run executables from stdin, pipes and ttys without creating a temporary file.
+- [otp-cli](https://github.com/chyroc/otp-cli) - Generate otp code in terminal, support copy to clipboard.
 
 ### System Interaction Utilities
 


### PR DESCRIPTION

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**

https://github.com/chyroc/otp-cli

**Description:**

Generate otp codes from the command line, and also support direct copying to the clipboard

**Why I think it's awesome:**

Sometimes I work next to my computer and don’t want to open the google auth authenticator in my phone. I can directly generate the otp code on my computer and copy it to my clipboard.

All of this can be done through the command line and integrated with other commands to complete all the work without leaving the keyboard!

