### PR TITLE
Add mail-deduplicate.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Buku](https://github.com/jarun/Buku) - Browser-independent bookmark manager.
 - [papis](https://github.com/papis/papis) - Extensible document and bibliography manager.
 - [pubs](https://github.com/pubs/pubs) - Scientific bibliography manager.
+- [mail-duplicate](https://github.com/kdeldycke/mail-deduplicate) - Deduplicate mails from mail boxes.
 
 ### Time Tracking
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**

https://github.com/kdeldycke/mail-deduplicate

**Description:**

Provides the `mdedup` CLI, an utility to deduplicate mails from a set of boxes.

**Why I think it's awesome:**

Lots of features:

- Duplicate detection based on cherry-picked and normalized mail headers.
- Fetch mails from multiple sources.
- Reads and writes to `mbox`, `maildir`, `babyl`, `mh` and `mmdf` formats.
- Deduplication strategies based on size, content, timestamp, file path or random choice.
- Copy, move or delete the resulting set of duplicates.
- Dry-run mode.
- Protection against false-positives by checking for size and content differences.
- Supports macOS, Linux and Windows.
- Shell auto-completion for Bash, Zsh and Fish.