### PR TITLE
Add cmd-ai

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [task-spooler](https://tracker.debian.org/pkg/task-spooler) - Queue jobs for linear execution.
 - [undollar](https://github.com/ImFeelingDucky/undollar) - Strip the '$' preceding copy-pasted terminal commands.
 - [pipe_exec](https://github.com/koraa/pipe_exec) - Run executables from stdin, pipes and ttys without creating a temporary file.
+- [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands (ei.: `ai Tell me the free space on disk`)
 
 ### System Interaction Utilities
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:** https://github.com/BrodaNoel/cmd-ai

**Description:** cmd-ai is a natural language shell assistant powered by AI. It turns plain English (or any prompt) into real, executable shell commands — with safety, explanation, history, and autocompletion built-in.

**Why I think it's awesome:** You can stop googling command lines like "How to check disk health and try to fix broken areas". You can now just run this on your console/terminal: `ai check disk health and try to fix broken areas`

