### PR TITLE
Add Telert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ipfs-deploy](https://github.com/agentofuser/ipfs-deploy) - Deploy static websites to [IPFS](https://github.com/ipfs/ipfs#overviewhttps://github.com/ipfs/ipfs#overview).
 - [Discharge](https://github.com/brandonweiss/discharge) - Deploy static websites to Amazon S3.
 - [updatecli](https://github.com/updatecli/updatecli) - A declarative dependency management tool.
-- [Telert](https://github.com/navig-me/telert) - Multi-channel alerts for long-running commands and process/log/uptime monitoring.
+- [telert](https://github.com/navig-me/telert) - Multi-channel alerts for long-running commands and process/log/uptime monitoring.
 - [logdy](https://github.com/logdyhq/logdy-core) - Supercharge terminal logs with web UI.
 - [s5cmd](https://github.com/peak/s5cmd) - Blazing fast S3 and local filesystem execution tool.
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**
https://github.com/navig-me/telert

**Description:**
Multi‑channel alerts for long‑running commands and process/log/uptime monitoring.

**Why I think it's awesome:**
Telert means I don’t have to babysit the terminal anymore. I just stick telert run (or the monitor command) in front of a long job and get a nudge on Telegram, Slack, email—whatever I’ve set—when it finishes or something goes wrong. One small, cross‑platform Python package replaces the pile of ad‑hoc scripts I used for job alerts, log watching, and uptime checks. It installs with a quick pip install telert, is fully open‑source, and just works.