### PR TITLE
add Package-installer-cli and email-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ## Development
 
+- [package-installer-cli](https://github.com/0xshariq/package-installer-cli) - A powerful, cross-platform CLI for modern development workflows. Create projects, manage dependencies, analyze codebases, and streamline your development process with intelligent automation.
 - [legit](https://github.com/captainsafia/legit) - Generate Open Source licences as files or file headers.
 - [mklicense](https://github.com/cezaraugusto/mklicense) - Create a custom LICENSE file painlessly with customized info.
 - [rebound](https://github.com/shobrook/rebound) - Fetch Stack Overflow results on compiler error.
@@ -279,6 +280,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 
 ## Productivity
 
+- [email-cli](https://github.com/0xshariq/email-mcp-server) - Cross-platform email operations for MCP clients and CLI 
 - [doing](https://github.com/ttscoff/doing/) - Keep track of what you’re doing and track what you’ve done.
 - [ffscreencast](https://github.com/cytopia/ffscreencast) - A ffmpeg screencast with video overlay and multi monitor support.
 - [meetup-cli](https://github.com/specious/meetup-cli) - Meetup.com client.


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [ ] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**
https://github.com/0xshariq/package-installer-cli
https://github.com/0xshariq/email-mcp-server ( ignore repo name )

**Description:**

**Why I think it's awesome:**
Package Installer CLI is my best project till now 
It contains 22 commands , 75 frameworks supported and database,aws,authentication and many more features which are ready to use for users
soon there will be premium templates added to this cli

Email CLI is simple but working email client through a cli
just change the env and user can switch from gmail to yahoo or any other smtp host

i don't have stars on both repo
i have to advertise both cli
so i choose this way
