### PR TITLE
Add webl - Domain intelligence CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [add-gitignore](https://github.com/TejasQ/add-gitignore) - Interactively generate a .gitignore for your project based on your needs.
 - [is-up-cli](https://github.com/sindresorhus/is-up-cli) - Check if a domain is up.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
+- [webl](https://github.com/WebsiteLaunches/webl-cli) - Domain intelligence lookups. Get domain authority, age, launch detection, and industry classification.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 
 ### Text Editors


### PR DESCRIPTION
Added webl to the Development section.

**webl** is a CLI tool for domain intelligence lookups:
- Domain authority scores (0-100) based on Common Crawl data
- Domain age and registration dates
- Launch detection and dates
- 3-level industry classification
- Free tier: 3,000 requests/month (no signup required)

**Installation:**
```bash
pip install webl
webl github.com
```

**Links:**
- GitHub: https://github.com/WebsiteLaunches/webl-cli
- PyPI: https://pypi.org/project/webl/
- Documentation: https://websitelaunches.com/docs