### PR TITLE
Add updo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,7 +221,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [telert](https://github.com/navig-me/telert) - Multi-channel alerts for long-running commands and process/log/uptime monitoring.
 - [logdy](https://github.com/logdyhq/logdy-core) - Supercharge terminal logs with web UI.
 - [s5cmd](https://github.com/peak/s5cmd) - Blazing fast S3 and local filesystem execution tool.
-- [updo](https://github.com/Owloops/updo) - Website monitoring tool with uptime tracking, response time metrics, SSL certificate monitoring, and multi-region support.
+- [updo](https://github.com/Owloops/updo) - Website monitoring tool.
 
 ### Docker
 


### PR DESCRIPTION
Updo is a command-line tool for monitoring website uptime and performance with real-time metrics, multi-region support, and alert notifications.

Repository: https://github.com/Owloops/updo
Created: December 26, 2023
License: MIT

This meets all requirements from the contributing guide: the repository is older than 90 days, has more than 20 stars, is open source, well documented, and easy to install.

Added to the Devops category. Thanks for maintaining this list.