### PR TITLE
Add CookCLI - Recipe manager with web server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,7 +290,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [Buku](https://github.com/jarun/Buku) - Browser-independent bookmark manager.
 - [fjira](https://github.com/mk-5/fjira) - Fuzzy finder and TUI application for Jira.
 - [OverTime](https://github.com/diit/overtime-cli) - Time-overlap tables for remote teams.
-- [CookCLI](https://github.com/cooklang/CookCLI) - Recipe manager with a built-in web server, shopping lists, and meal planning.
+- [CookCLI](https://github.com/cooklang/CookCLI) - Full-featured recipe manager.
 
 ### Time Tracking
 


### PR DESCRIPTION
CookCLI is a command-line recipe management tool that fits well in the Productivity section.

**Features:**
- Built-in web server for browsing recipes
- Shopping list generation from recipes
- Meal planning capabilities
- Plain-text recipe format (Cooklang)
- Written in Rust for performance
- Cross-platform support

This tool is actively maintained and provides a practical CLI interface for managing recipes, making it a great addition to the productivity tools list.

Repository: https://github.com/cooklang/CookCLI
Website: https://cooklang.org/