### PR TITLE
Replace spotify-tui with spotatui

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,13 +109,12 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [moc](http://moc.daper.net/) - Console audio player for Linux/UNIX.
 - [musikcube](https://github.com/clangen/musikcube) - Cross-platform, terminal-based music player, audio engine, metadata indexer, and server.
 - [beets](https://github.com/beetbox/beets) - Music library manager and tagger.
-- [spotify-tui](https://github.com/Rigellute/spotify-tui) - Spotify client.
+- [spotatui](https://github.com/LargeModGames/spotatui) - Spotify client.
 - [swaglyrics-for-spotify](https://github.com/SwagLyrics/SwagLyrics-For-Spotify) - Spotify lyrics.
 - [dzr](https://github.com/yne/dzr) - deezer.com player.
 - [radio-active](https://github.com/deep5050/radio-active) - Internet radio player with 40k+ stations.
 - [mpvc](https://github.com/gmt4/mpvc) - Music player interfacing mpv.
 - [TUISIC](https://github.com/Dark-Kernel/tuisic) - Login-free music streaming.
-- [spotatui](https://github.com/LargeModGames/spotatui) - Spotify client with native streaming, synced lyrics, and audio visualization.
 
 ### Video
 


### PR DESCRIPTION
<!---
Thank you for your pull request.
Please check the contribution guidelines for what is required of the app and this PR.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/LargeModGames/spotatui

**Description:**
Spotify client with native streaming, synced lyrics, and audio visualization. A community-maintained fork of spotify-tui (already on this list, but unmaintained since 2021).

**Why I think it's awesome:**
- Native streaming via librespot, no need for spotifyd or the official Spotify app
- Synced lyrics display while playing
- Real-time audio visualization (cross-platform)
- Lightweight (~48 MB RAM vs Electron client)
- 11,700+ songs played by users since December 5th, 2024
- Actively maintained with regular updates

**Note on 90-day rule:** The fork itself is ~24 days old, but it's built on spotify-tui's 4+ year mature codebase. Happy to wait and resubmit if maintainers prefer.