### PR TITLE
Add okitsok to Network Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -393,6 +393,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gg](https://github.com/mzz2017/gg) - One-click proxy without installing v2ray or anything else.
 - [rustnet](https://github.com/domcyrus/rustnet) - Network monitoring with process identification and deep packet inspection.
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Transparent proxy server that works as a poor man's VPN.
+- [okitsok](https://github.com/coconut971/okitsok) - Local DNS-based CLI tool to check domain name availability (machine-readable JSON output).
 
 ### Theming and Customization
 


### PR DESCRIPTION
okitsok is a local CLI tool that checks domain availability using DNS queries.
It provides deterministic JSON output and does not rely on external APIs or registrars.
