### PR TITLE
Add agent-smith

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [grex](https://github.com/pemistahl/grex) - Generate regular expressions from user-provided test cases.
 - [iola](https://github.com/pvarentsov/iola) - Socket client with REST API.
 - [add-gitignore](https://github.com/TejasQ/add-gitignore) - Interactively generate a .gitignore for your project based on your needs.
+- [agent-smith](https://github.com/jpoindexter/agentsmith) - Generate AGENTS.md context files for AI coding assistants.
 - [is-up-cli](https://github.com/sindresorhus/is-up-cli) - Check if a domain is up.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.


### PR DESCRIPTION
Adding agent-smith to the Development section.

**Entry:** `- [agent-smith](https://github.com/jpoindexter/agentsmith) - Generate AGENTS.md context files for AI coding assistants.`

[AGENTS.md](https://agents.md) is an open standard for giving AI coding tools context about your project. agent-smith scans codebases and auto-generates these context files.

**npm:** `npx @jpoindexter/agent-smith`