### PR TITLE
Add olcli - Overleaf CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [is-up-cli](https://github.com/sindresorhus/is-up-cli) - Check if a domain is up.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
+- [olcli](https://github.com/aloth/olcli) - Sync and manage LaTeX projects from Overleaf.
 
 ### Text Editors
 


### PR DESCRIPTION
Adds [olcli](https://github.com/aloth/olcli) to the Development section.

**olcli** is a command-line interface for Overleaf that allows developers to sync, manage, and compile LaTeX projects from the terminal.

**Features:**
- Pull/push LaTeX projects between local filesystem and Overleaf
- Bidirectional sync with conflict detection
- Compile PDFs using Overleaf's remote compiler
- Download compile artifacts (.bbl, .log, .aux) for arXiv submissions
- Works with npm and Homebrew

Perfect for developers who prefer local editing (Vim, VS Code, Emacs) with Git version control while using Overleaf's compilation service.