### PR TITLE
Add mac-ops

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [dark-mode](https://github.com/sindresorhus/dark-mode) - Toggle dark mode.
 - [clippy](https://github.com/neilberkman/clippy) - Clipboard tool for interacting with GUI applications.
 - [anvil](https://github.com/0xjuanma/anvil) - Config management and app installations.
+- [mac-ops](https://github.com/seunggabi/mac-ops) - Safe macOS system optimizer with 72-hour trash recovery and zero dependencies.
 
 ### Terminal Sharing Utilities
 


### PR DESCRIPTION
## Description

Adding **[mac-ops](https://github.com/seunggabi/mac-ops)** to the Utilities > macOS section.

A macOS system optimizer that cleans caches, temp files, logs, and zombie processes while maintaining a 72-hour trash recovery safety net.

## Why it fits

mac-ops follows the "do one thing and do it well" philosophy — it optimizes macOS systems through targeted cleanup modules with strict safety guardrails (5-layer protection, 72-hour recovery, process protection). Built on pure zsh with zero external dependencies, making it easy to install and audit.

## Requirement Checklist

- [x] **Does one thing well:** System optimization and cleanup with safety-first approach
- [x] **Free and open source:** MIT Licensed
- [x] **Easy to install:** `brew tap seunggabi/mac-ops && brew install mac-ops` or git clone
- [x] **Well documented:** Comprehensive README, CLI help, 108+ tests
- [x] **90+ days old:** Active since initial release
- [x] **20+ GitHub stars:** [seunggabi/mac-ops](https://github.com/seunggabi/mac-ops)