### PR TITLE
Add sql-splitter to Database section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [sqlline](https://github.com/julianhyde/sqlline) - Shell for issuing SQL via JDBC.
 - [iredis](https://github.com/laixintao/iredis) - Redis client with autocompletion and syntax highlighting.
 - [usql](https://github.com/xo/usql) - Universal SQL client with autocompletion and syntax highlighting.
+- [sql-splitter](https://github.com/HelgeSverre/sql-splitter) - Split, merge, convert, and analyze SQL dump files across MySQL, PostgreSQL, SQLite, and MSSQL.
 
 ### Devops
 


### PR DESCRIPTION
Adds [sql-splitter](https://github.com/HelgeSverre/sql-splitter) to the **Database** section.

sql-splitter is a CLI for splitting, merging, converting, and analyzing SQL dump files across MySQL, PostgreSQL, SQLite, and MSSQL. Built in Rust with a streaming architecture for efficient processing of large dump files.

Website: https://www.sql-splitter.dev