### PR TITLE
Add vnsh to File Sync/Sharing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -590,6 +590,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gdrive-downloader](https://github.com/Akianonymus/gdrive-downloader) - Download files/folders from Google Drive.
 - [portal](https://github.com/ZinoKader/portal) - Send files between computers.
 - [shbin](https://github.com/Shiphero/shbin/) - Turn a Github repo into a pastebin.
+- [vnsh](https://github.com/raullenchai/vnsh) - Encrypted ephemeral file sharing. Zero-knowledge pastebin with auto-expiring links.
 - [sharing](https://github.com/parvardegr/sharing) - Send and receive files on your mobile device.
 - [ncp](https://github.com/kha7iq/ncp) - Transfer files and folders, to and from NFS servers.
 - [share](https://github.com/beavailable/share) - Share and receive files effortlessly over HTTP.


### PR DESCRIPTION
## Adding vnsh

**GitHub:** https://github.com/raullenchai/vnsh
**Website:** https://vnsh.dev

### What is vnsh?

vnsh is an encrypted ephemeral file sharing CLI tool. Think of it as a zero-knowledge pastebin with auto-expiring links.

**Install:**
```bash
curl -sL vnsh.dev/i | sh
```

**Usage:**
```bash
# Share text
echo "hello" | vn

# Share file
vn myfile.txt

# Output: https://vnsh.dev/v/{id}#k={key}&iv={iv}
```

**Features:**
- Zero-knowledge (server never sees decryption keys)
- Client-side AES-256-CBC encryption
- Auto-expiring links (24h default)
- Works with just curl + openssl