### PR TITLE
Add qbo-cli to Finance section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -333,6 +333,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [cash-cli](https://github.com/xxczaki/cash-cli) - Convert Currency Rates.
 - [cointop](https://github.com/miguelmota/cointop) - Track cryptocurrencies.
 - [ticker](https://github.com/achannarasappa/ticker) - Stock ticker.
+- [qbo-cli](https://github.com/alexph-dev/qbo-cli) - Command-line interface for QuickBooks Online API.
 
 ### Presentations
 


### PR DESCRIPTION
Adding [qbo-cli](https://github.com/alexph-dev/qbo-cli) — a command-line interface for the QuickBooks Online API.

Features include OAuth2 auth, SQL-like queries, CRUD operations, financial reports, and JSON/TSV output. Published on PyPI (`pip install qbo-cli`).

Available on [PyPI](https://pypi.org/project/qbo-cli/).