### PR TITLE
Add psmux, pstop, and psnet to System Interaction Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -426,6 +426,9 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [glances](https://nicolargo.github.io/glances/) - System monitoring tool.
 - [tiptop](https://github.com/nschloe/tiptop) - System monitor.
 - [gzip-size-cli](https://github.com/sindresorhus/gzip-size-cli) - Get the gzipped size of a file.
+- [psmux](https://github.com/marlocarlo/psmux) - tmux-compatible terminal multiplexer for Windows.
+- [psnet](https://github.com/marlocarlo/psnet) - Real-time TUI network monitor for Windows.
+- [pstop](https://github.com/marlocarlo/pstop) - htop-style system monitor for Windows.
 
 ### Markdown
 


### PR DESCRIPTION
Adding three Windows-native TUI tools built in Rust:

- **psmux** — tmux-compatible terminal multiplexer for Windows
- **pstop** — htop-style system monitor for Windows
- **psnet** — Real-time TUI network monitor for Windows

All published on crates.io and actively maintained.