### PR TITLE
Add gabe-monitor — cron job heartbeat monitor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [s5cmd](https://github.com/peak/s5cmd) - Blazing fast S3 and local filesystem execution tool.
 - [updo](https://github.com/Owloops/updo) - Website monitoring tool.
 - [cronboard](https://github.com/antoniorodr/Cronboard) - Dashboard for managing cron jobs.
+- [gabe-monitor](https://github.com/Scolliq/gabe) - Cron job heartbeat monitor with Slack/Discord alerts.
 - [s3m](https://github.com/s3m/s3m) - Stream of data into S3 buckets.
 
 ### Docker


### PR DESCRIPTION
Adds [gabe-monitor](https://github.com/Scolliq/gabe) to the DevOps section next to cronboard and updo.

gabe-monitor is a CLI for managing cron job heartbeat monitors. Install with `npm i -g gabe-monitor`, then use `gabe create --name my-job --interval 60` to set up monitoring. If a cron job misses its expected ping, you get a Slack/Discord webhook alert.

- Open source (MIT)
- Available on npm: `gabe-monitor`
- No dependencies