### PR TITLE
Add releaserun to Devops section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [ipfs-deploy](https://github.com/agentofuser/ipfs-deploy) - Deploy static websites to [IPFS](https://github.com/ipfs/ipfs#overviewhttps://github.com/ipfs/ipfs#overview).
 - [Discharge](https://github.com/brandonweiss/discharge) - Deploy static websites to Amazon S3.
 - [updatecli](https://github.com/updatecli/updatecli) - A declarative dependency management tool.
+- [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan dependencies for end-of-life status, CVEs, and version health.
 - [telert](https://github.com/navig-me/telert) - Multi-channel alerts for long-running commands and process/log/uptime monitoring.
 - [logdy](https://github.com/logdyhq/logdy-core) - Supercharge terminal logs with web UI.
 - [s5cmd](https://github.com/peak/s5cmd) - Blazing fast S3 and local filesystem execution tool.


### PR DESCRIPTION
Adds [releaserun](https://github.com/Releaserun/releaserun-cli) to the Devops section.

A CLI tool that scans your project for dependency files and reports EOL status, known CVEs, and overall health for each detected technology. Supports package.json, requirements.txt, go.mod, Gemfile, Cargo.toml, and pom.xml.

Install: `npm install -g releaserun` or `npx releaserun check`