### PR TITLE
Add clipslots

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -426,6 +426,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [glances](https://nicolargo.github.io/glances/) - System monitoring tool.
 - [tiptop](https://github.com/nschloe/tiptop) - System monitor.
 - [gzip-size-cli](https://github.com/sindresorhus/gzip-size-cli) - Get the gzipped size of a file.
+- [clipslots](https://github.com/olafglad/clipSlots) - Named clipboard slots with global hotkeys for macOS.
 
 ### Markdown
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/olafglad/clipSlots

**Description:** A lightweight clipboard slot manager for macOS — save text to named slots and paste them back with global hotkeys. Free and MIT-licensed.

**Why I think it's awesome:** It fills a gap in macOS clipboard tooling — instead of just clipboard history, you get persistent named slots you can save/recall instantly via hotkeys or CLI, which is great for repetitive workflows.