### PR TITLE
Add KeyEnv to Security section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN.
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
+- [KeyEnv](https://keyenv.dev) - Team secrets manager: replaces .env files with encrypted, per-environment secrets injected at runtime via CLI.
 
 ### Math
 


### PR DESCRIPTION
KeyEnv (https://keyenv.dev) is a CLI-first secrets manager that replaces scattered .env files with AES-256 encrypted, team-scoped secrets. Developers run `keyenv run -- your-command` and secrets are injected at runtime — no file ever touches disk. Fits naturally alongside pass and gopass in the Security section as a modern alternative for development teams.