### PR TITLE
Add OpenBoot - Mac dev environment manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [dark-mode](https://github.com/sindresorhus/dark-mode) - Toggle dark mode.
 - [clippy](https://github.com/neilberkman/clippy) - Clipboard tool for interacting with GUI applications.
 - [anvil](https://github.com/0xjuanma/anvil) - Config management and app installations.
+- [OpenBoot](https://github.com/openbootdotdev/openboot) - Dev environment manager that captures and restores Homebrew packages, casks, dotfiles, shell config, and macOS preferences.
 
 ### Terminal Sharing Utilities
 


### PR DESCRIPTION
## OpenBoot

[OpenBoot](https://github.com/openbootdotdev/openboot) is an open-source Mac dev environment manager CLI tool.

**What it does:**
- Captures Homebrew packages/casks, dotfiles, shell config, and macOS preferences
- Restores everything with one command on a new Mac
- Interactive TUI (Charmbracelet/Bubble Tea)
- Per-project `.openboot.yml` config
- `--dry-run` flag on all destructive commands

**Details:**
- MIT licensed, zero telemetry
- Install: `brew install openbootdotdev/tap/openboot`
- GitHub: https://github.com/openbootdotdev/openboot