### PR TITLE
Add note-cli — Quick note taking CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,6 +321,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [taskbook](https://github.com/klaussinani/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [dnote](https://github.com/dnote/dnote) - A interactive, multi-device notebook.
 - [nb](https://github.com/xwmx/nb) - A note‑taking, bookmarking, archiving, and knowledge base application.
+- [note-cli](https://github.com/leomekhe-tech/note-cli) - Quick note taking from terminal with search and timestamps.
 - [obsidian-cli](https://github.com/Yakitrak/obsidian-cli) - Interact with your Obsidian vault.
 - [journalot](https://github.com/jtaylortech/journalot) - Journaling tool with git sync.
 


### PR DESCRIPTION
Adds [note-cli](https://github.com/leomekhe-tech/note-cli) to the Note Taking and Lists section.

**What it does:** Quick note capture, list, search from terminal. Zero dependencies, pure Bash.

**Why include it:** Complements existing tools with simple timestamp-based storage and full-text search.

**Repo:** https://github.com/leomekhe-tech/note-cli
- 121 lines of Bash
- 0 dependencies
- MIT licensed