### PR TITLE
Add PolySkill - open marketplace for LLM-agnostic skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 
+- [PolySkill](https://polyskill.ai) - Open marketplace for LLM-agnostic skills that work with Claude Code, Codex, and other AI assistants. `npm install -g @polyskill/cli`
 ### Text Editors
 
 - [emacs](https://github.com/emacs-mirror/emacs) - An extensible, customizable, free/libre text editor — and more.


### PR DESCRIPTION
Add [PolySkill](https://polyskill.ai) - An open marketplace for LLM-agnostic skills.

**What it does:**
PolySkill is a CLI tool and marketplace for discovering, installing, and publishing portable AI skills that work across Claude Code, GitHub Copilot, Cursor, and other AI coding assistants.

**Why add it:**
- Open source (MIT license)
- Cross-platform CLI
- Growing community of AI skills
- Solves the fragmentation problem across AI assistants

**Installation:**
```bash
npm install -g @polyskill/cli
```

**Example usage:**
```bash
polyskill search weather
polyskill install @polyskill/getting-started
```

Website: https://polyskill.ai  
GitHub: https://github.com/polyskill/polyskill-cli
