### PR TITLE
Add dna-claude-analysis to Science section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -479,6 +479,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 
 ### Science
 
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates a terminal-style HTML visualization.
 - [periodic-table-cli](https://github.com/spirometaxas/periodic-table-cli) - View and explore the Periodic Table of Elements.
 
 ## Command Line Learning


### PR DESCRIPTION
## What

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Science** section, placed alphabetically before `periodic-table-cli`.

## Why

`dna-claude-analysis` is a CLI toolkit for personal genome analysis. It processes raw DNA data files (e.g. from 23andMe or AncestryDNA) using Python scripts and produces structured reports across 17 categories including health risks, ancestry, pharmacogenomics, nutrition, sports traits, psychology, and more. The final output is a self-contained terminal-style single-page HTML visualization with no external dependencies.

It fits the Science section as a bioinformatics/genomics CLI tool.

## Checklist

- Only one item added
- Entry is in alphabetical order within the section
- Format matches existing entries
- Link points to a public GitHub repository