### PR TITLE
Add pixelmuse to Images section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -674,6 +674,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Generate beautiful images of your code.
 - [imgur-uploader-cli](https://github.com/kevva/imgur-uploader-cli) - Upload images to imgur.
 - [pageres-cli](https://github.com/sindresorhus/pageres-cli) - Capture website screenshots.
+- [pixelmuse](https://github.com/starmorph/pixelmuse-cli) - AI image generation with 6 models, interactive TUI, and MCP server for AI agents.
 
 ### Gif Creation
 


### PR DESCRIPTION
Adds [pixelmuse](https://github.com/starmorph/pixelmuse-cli) to the **Images** section.

**What it does:** AI image generation from the terminal with 6 models (Flux, Imagen 3, Recraft V4, Nano Banana), an interactive TUI, and an MCP server for AI agents.

- **npm:** https://www.npmjs.com/package/pixelmuse
- **Install:** `npm install -g pixelmuse`
- **Website:** https://pixelmuse.studio/developers/cli
- **Node.js 20+**, MIT-compatible (BSL 1.1)