### PR TITLE
Add git-graphable to Version Control -> Git section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -641,6 +641,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [tig](https://github.com/jonas/tig) - Text-mode interface for git.
 - [grv](https://github.com/rgburke/grv) - Text-mode interface for git with customisable vi bindings.
 - [git-standup](https://github.com/kamranahmedse/git-standup) - Recall what you did on the last working day.
+- [git-graphable](https://github.com/TheTrueSCU/git-graphable) - Interactive Git history visualization and repository hygiene analysis tool.
 - [git-secret](https://github.com/sobolevn/git-secret) - Store your private data inside a git repository.
 - [gitlab-cli](https://github.com/vishwanatharondekar/gitlab-cli) - Create GitLab merge requests.
 - [git-extras](https://github.com/tj/git-extras) - Git utilities.


### PR DESCRIPTION
I'm submitting `git-graphable`, a CLI tool for visualizing Git history. Unlike standard graph tools, it includes an "Interactive Legend" in its HTML export to toggle different hygiene overlays (stale commits, PR status, silos) and provides a numeric hygiene score for the repository. It's written in Python and supports multiple output engines (Mermaid, D2, HTML).