### PR TITLE
Add duplicacy-cli-cron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [updo](https://github.com/Owloops/updo) - Website monitoring tool.
 - [cronboard](https://github.com/antoniorodr/Cronboard) - Dashboard for managing cron jobs.
 - [s3m](https://github.com/s3m/s3m) - Stream of data into S3 buckets.
+- [duplicacy-cli-cron](https://github.com/GeiserX/duplicacy-cli-cron) - Automated encrypted backups with Duplicacy on a cron schedule.
 
 ### Docker
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/GeiserX/duplicacy-cli-cron

**Description:** A Docker container that runs Duplicacy CLI backups on a cron schedule with configurable retention policies and encrypted dual-storage redundancy.

**Why I think it's awesome:** It simplifies automated encrypted backups by wrapping Duplicacy CLI in a ready-to-use Docker container with cron scheduling and flexible retention policies, making robust backup automation accessible with minimal configuration.