### PR TITLE
Add duplicacy-cli-cron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,6 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [PingMe](https://github.com/kha7iq/pingme) - Send messages/alerts to multiple messaging platforms & email.
 - [ipfs-deploy](https://github.com/agentofuser/ipfs-deploy) - Deploy static websites to [IPFS](https://github.com/ipfs/ipfs#overviewhttps://github.com/ipfs/ipfs#overview).
 - [Discharge](https://github.com/brandonweiss/discharge) - Deploy static websites to Amazon S3.
-- [duplicacy-cli-cron](https://github.com/GeiserX/duplicacy-cli-cron) - Docker-based encrypted dual-storage backup automation using Duplicacy CLI with cross-site redundancy.
 - [updatecli](https://github.com/updatecli/updatecli) - A declarative dependency management tool.
 - [telert](https://github.com/navig-me/telert) - Multi-channel alerts for long-running commands and process/log/uptime monitoring.
 - [logdy](https://github.com/logdyhq/logdy-core) - Supercharge terminal logs with web UI.
@@ -227,6 +226,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [updo](https://github.com/Owloops/updo) - Website monitoring tool.
 - [cronboard](https://github.com/antoniorodr/Cronboard) - Dashboard for managing cron jobs.
 - [s3m](https://github.com/s3m/s3m) - Stream of data into S3 buckets.
+- [duplicacy-cli-cron](https://github.com/GeiserX/duplicacy-cli-cron) - Docker-based encrypted dual-storage backup automation using Duplicacy CLI with cross-site redundancy.
 
 ### Docker
 


### PR DESCRIPTION
Adds [duplicacy-cli-cron](https://github.com/GeiserX/duplicacy-cli-cron) to the Devops section.

A Docker container that schedules and runs Duplicacy CLI backups on a cron schedule, with Apprise notifications support.