### PR TITLE
Add greywall

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN.
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
+- [greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default sandbox for CLI commands with filesystem and network isolation.
 
 ### Math
 


### PR DESCRIPTION
- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/GreyhavenHQ/greywall

**Description:** Greywall is a deny-by-default command sandbox that restricts filesystem access and redirects network traffic through a transparent proxy. It supports Linux (bubblewrap + seccomp/Landlock/eBPF) and macOS (Seatbelt profiles), with built-in profiles for agents like Claude Code or OpenCode.

**Why I think it's awesome:** There are no sandboxing or process-isolation tools in the current list. As AI coding agents become mainstream, greywall fills a critical gap by letting developers run untrusted CLI tools and agents with deny-by-default filesystem and network controls, without containers or VMs.