### PR TITLE
Add ORCH — CLI orchestrator for AI agent teams

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [updo](https://github.com/Owloops/updo) - Website monitoring tool.
 - [cronboard](https://github.com/antoniorodr/Cronboard) - Dashboard for managing cron jobs.
 - [s3m](https://github.com/s3m/s3m) - Stream of data into S3 buckets.
+- [ORCH](https://github.com/oxgeneral/ORCH) - Orchestrator for AI agent teams (Claude, Codex, Cursor). Parallel task dispatch, state machine, and autonomous mode. TypeScript, MIT.
 
 ### Docker
 


### PR DESCRIPTION
## What is ORCH?

[ORCH](https://github.com/oxgeneral/ORCH) is a CLI orchestrator for AI agent teams (Claude Code, OpenAI Codex, Cursor, shell scripts).

**Fits in**: Development → Devops section

## Why it belongs here

- CLI tool installable via npm
- DevOps workflow automation with AI agents
- TypeScript, MIT license, 987 passing tests (Vitest), strict mode
- Active project with regular releases (v0.3.0)

## Checklist

- [x] MIT license
- [x] Not a duplicate
- [x] Description: one sentence, ends with period
- [x] Link works

**Repo**: https://github.com/oxgeneral/ORCH