### PR TITLE
Add kbot — open-source terminal AI agent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,6 +297,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [OverTime](https://github.com/diit/overtime-cli) - Time-overlap tables for remote teams.
 - [CookCLI](https://github.com/cooklang/CookCLI) - Full-featured recipe manager.
 - [hns](https://github.com/primaprashant/hns) - Speech-to-text tool to transcribe voice from microphone.
+- [kbot](https://github.com/isaacsight/kernel) - Open-source terminal AI agent with 39 specialists, 167 tools, and 19 providers.
 
 ### Time Tracking
 


### PR DESCRIPTION
## Add kbot to Productivity section

[kbot](https://github.com/isaacsight/kernel) is an open-source terminal AI agent with 39 specialist agents, 167 built-in tools, and support for 19 AI providers.

- **MIT licensed**
- **Install**: `npm install -g @kernel.chat/kbot`
- **GitHub**: https://github.com/isaacsight/kernel
- **npm**: https://www.npmjs.com/package/@kernel.chat/kbot

kbot is terminal-first, supports multi-provider AI (Anthropic, OpenAI, Google, DeepSeek, local models via Ollama, and more), and includes built-in tools for file operations, git, GitHub, web search, browser automation, and MCP server support.