### PR TITLE
Add mcp-doctor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN.
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
+- [mcp-doctor](https://github.com/realwigu/mcp-doctor) - Diagnose, secure, and benchmark MCP servers across Claude Code, Cursor, VS Code, and Windsurf.
 
 ### Math
 


### PR DESCRIPTION
Adds [mcp-doctor](https://github.com/realwigu/mcp-doctor) — a zero-config CLI that auto-discovers MCP server configs, tests connections via JSON-RPC, flags hardcoded secrets, and benchmarks latency. TypeScript, MIT licensed.