### PR TITLE
Add zsh-paste-guard to Security section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN.
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
+- [zsh-paste-guard](https://github.com/stefanoamorelli/zsh-paste-guard) - Prevent clipboard injection attacks in ZSH.
 
 ### Math
 


### PR DESCRIPTION
## Description

Add [zsh-paste-guard](https://github.com/stefanoamorelli/zsh-paste-guard) to the Security section under Utilities.

**zsh-paste-guard** is a ZSH plugin that detects pasted commands and requires a typed confirmation phrase before execution, preventing clipboard injection attacks. No external dependencies — uses only ZSH builtins.