### PR TITLE
Add ORCH — CLI orchestrator for AI agent teams

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -783,6 +783,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - Coding agent session manager via tmux and git worktrees.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator for running Claude, Codex, and Cursor as a coordinated AI team.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/oxgeneral/ORCH

**Description:** CLI orchestrator for running Claude, Codex, and Cursor as a coordinated AI team.

**Why I think it's awesome:** ORCH turns your AI tools into a managed engineering team from one terminal. You add agents (Claude Code, Codex, Cursor, shell), create tasks with `orch task add`, and run them all in parallel with `orch run --all`. Features include: validated state machine (todo → in_progress → review → done), auto-retry on agent failure, inter-agent messaging, shared context store, and a real-time Ink/React TUI dashboard. One `npm install -g @oxgeneral/orch`. TypeScript strict mode, MIT license, 1647 tests passing.

**Section:** AI → Agents