### PR TITLE
Add ORCH — CLI AI agent orchestration runtime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -780,6 +780,7 @@ Inclusion criteria are less strict for this fast-moving field.
 
 ### Agents
 - [greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default sandbox with filesystem and network isolation.
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime that orchestrates AI agent teams (Claude, Codex, Cursor) with state machine, auto-retry, inter-agent messaging, and TUI dashboard.
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - Coding agent session manager via tmux and git worktrees.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.


### PR DESCRIPTION
## Add ORCH to the AI > Agents section

[ORCH](https://github.com/oxgeneral/ORCH) is a CLI runtime for orchestrating teams of AI coding agents from the terminal.

**Why it belongs in the Agents section:**
- Coordinates Claude Code, OpenCode (Codex/Gemini), Cursor, and shell scripts as a typed AI engineering team
- Formal state machine: `todo → in_progress → review → done` with mandatory review gate
- Auto-retry on failure, inter-agent messaging, shared context store
- Real-time TUI dashboard (Ink/React) for monitoring parallel agents
- CLI-first, available via: `npm install -g @oxgeneral/orch`
- MIT license, 1,647 tests, strict TypeScript

**Entry added (alphabetically in Agents section):**
```
- [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime that orchestrates AI agent teams (Claude, Codex, Cursor) with state machine, auto-retry, inter-agent messaging, and TUI dashboard.
```