### PR TITLE
Add need - semantic CLI tool discovery

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -783,6 +783,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - Coding agent session manager via tmux and git worktrees.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
+- [need](https://github.com/tuckerschreiber/need) - Semantic search across 10,000+ CLI tools — find the right tool by describing what you need in plain English. Works standalone or as an MCP server for AI coding agents.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
**need** is a CLI tool (and MCP server) that gives you semantic search across 10,000+ verified CLI tools.

Instead of Googling "best tool to compress images", you just run:
```bash
need compress png images
```

And get ranked results with install commands and community success rates.

Also works as an MCP server so AI coding agents (Claude Code, Cursor) can autonomously discover and install tools.

Repo: https://github.com/tuckerschreiber/need