### PR TITLE
Add TeamHero to AI > Agents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -785,6 +785,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - Coding agent session manager via tmux and git worktrees.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
+- [TeamHero](https://github.com/sagiyaacoby/TeamHero) - Multi-agent orchestration platform for Claude Code. Manage AI agent teams with a web dashboard, task lifecycle, and round-table coordination.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adding TeamHero to the AI > Agents section.

TeamHero is an open-source multi-agent orchestration platform for Claude Code. It lets you manage teams of AI agents with a web dashboard, task lifecycle with version tracking, knowledge base, and round-table coordination sessions. Built with Node.js, no database required.

Repo: https://github.com/sagiyaacoby/TeamHero