### PR TITLE
Add gh-star-history

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -710,6 +710,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [CLI GitHub](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
+- [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts.
 
 ### Emoji
 


### PR DESCRIPTION
Visualize and compare GitHub star history as interactive charts, powered by the gh CLI. Zero dependencies.

- [gh-star-history](https://github.com/ykdojo/gh-star-history)