### PR TITLE
Add envscan - CLI tool for scanning .env variable usage in codebases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
+- [envscan](https://github.com/ckmtools/envscan) - Scan codebases for .env variable usage and generate documentation.
 
 ### Text Editors
 


### PR DESCRIPTION
## What is being added?

[envscan](https://github.com/ckmtools/envscan) - Scan codebases for `.env` variable usage and generate documentation.

envscan is a CLI tool that:
- Scans source code files to discover all environment variables referenced in a project
- Generates a `.env.example` with discovered variables and their usage context
- Helps teams document required environment variables automatically

## Why does it belong here?

It's a developer productivity CLI tool that fits naturally in the **Development** section alongside other project-setup and code-analysis tools like `add-gitignore` and `diff2html-cli`.

## Checklist

- [x] Entry added in alphabetical position relative to similar entries
- [x] Description is a single sentence ending with a period
- [x] Description starts with a capital letter
- [x] Linked project is an open source CLI tool
- [x] No trailing whitespace