### PR TITLE
Add tunelo to HTTP Tunnel section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,6 +205,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [localtunnel](https://github.com/localtunnel/localtunnel)
 - [tunnelmole](https://github.com/robbie-cahill/tunnelmole-client)
 - [ngrok](https://ngrok.com/)
+- [tunelo](https://github.com/jiweiyuan/tunelo) - Expose localhost via QUIC tunnel with built-in file explorer.
 
 ### Mobile Development
 


### PR DESCRIPTION
[tunelo](https://github.com/jiweiyuan/tunelo) — Expose localhost via QUIC tunnel with built-in file explorer. Single Rust binary, self-hostable. MIT License.