### PR TITLE
Add spec2cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [ain](https://github.com/jonaslu/ain) - HTTP client with a simple format to organize API endpoints.
 - [curlie](https://github.com/rs/curlie) - A curl frontend with the ease of use of HTTPie.
 - [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
+- [spec2cli](https://github.com/lucianfialho/spec2cli) - Turn any OpenAPI spec into a CLI instantly.
 
 ### Testing
 


### PR DESCRIPTION
[spec2cli](https://github.com/lucianfialho/spec2cli) — Turn any OpenAPI spec into a CLI instantly. No code generation, no build step.

Point it at an OpenAPI 3.x or Swagger 2.0 spec and get a working CLI with commands, flags, auth, and formatted output.

```bash
npx spec2cli --spec ./api.yaml pets list --status available
```

Published on npm: https://www.npmjs.com/package/spec2cli