### PR TITLE
Add atuin to Shell Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -443,6 +443,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [envio](https://github.com/envio-cli/envio) - Manage environment variables securely.
 - [await](https://github.com/slavaGanzin/await) - Runs commands in parallel and waits for their termination.
 - [aha](https://github.com/theZiz/aha) - Convert ANSI output to HTML.
+- [atuin](https://github.com/atuinsh/atuin) - Magical shell history with full-text search, timestamps, and optional encrypted sync across machines.
 
 ### System Interaction Utilities
 


### PR DESCRIPTION
Adds [atuin](https://github.com/atuinsh/atuin) — a shell history tool with full-text search, timestamps, and optional encrypted sync. It has 22k+ stars and is actively maintained. Currently missing from the list.