### PR TITLE
Add Claude Code Starter Kit to Agents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -786,6 +786,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
 - [Shep](https://github.com/shep-ai/cli) - Multi-session SDLC control center for AI coding agents.
+- [Claude Code Starter Kit](https://github.com/rmbell09-lang/claude-code-starter-kit) - Production-ready workspace setup with persistent memory, skills, and AGENTS.md for consistent Claude coding agents.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## Claude Code Starter Kit

Adding [Claude Code Starter Kit](https://github.com/rmbell09-lang/claude-code-starter-kit) to the Agents section.

**What it does:** Production-ready workspace setup for Claude Code — includes persistent memory (MEMORY.md), AGENTS.md, SOUL.md persona file, and 5 pre-built skills. Gets consistent, context-aware Claude coding agents in ~10 minutes.

**Why it belongs here:** It is a CLI-focused agent workspace toolkit — directly relevant to the Agents section alongside similar tools like Shep and agent-deck.

- GitHub: https://github.com/rmbell09-lang/claude-code-starter-kit
- Stars: 44
- License: MIT