### PR TITLE
Add apicmd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -786,6 +786,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
 - [Shep](https://github.com/shep-ai/cli) - Multi-session SDLC control center for AI coding agents.
+- [apicmd](https://github.com/charlie103721/apicmd) - Turn any API into a CLI with named commands and parameter validation.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## What is apicmd?

[apicmd](https://github.com/charlie103721/apicmd) is a CLI tool that turns any API into a CLI with named commands and parameter validation.

- **OpenAPI-native**: Give it an OpenAPI spec URL and it generates a CLI with named operations, parameter validation, and `--help`
- **Raw mode**: Works with any HTTP API — learns endpoints from your usage history
- **Designed for LLM agents**: Agents discover and call APIs via `--help` and structured error messages
- **Zero dependencies, 26KB**
- **MIT licensed**

## Where I added it

Added to **AI > Agents** (bottom of the category, per contributing guidelines).

## Why it fits

apicmd is designed specifically so LLM agents can interact with any API through a CLI interface. It auto-generates help text and validates parameters, which makes it a natural fit for the AI Agents category — tools that help AI coding agents work more effectively.