### PR TITLE
Add cli-anything-web to Development section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
+- [cli-anything-web](https://github.com/ItamarZand88/CLI-Anything-WEB) - Generate Python CLIs for any website by capturing HTTP traffic via Playwright.
 
 ### Text Editors
 


### PR DESCRIPTION
**[cli-anything-web](https://github.com/ItamarZand88/CLI-Anything-WEB)** — Generate Python CLIs for any website by capturing HTTP traffic via Playwright.

Point at a URL, capture API traffic, and get a complete Python CLI with Click commands, `--json` output, auth, REPL mode, and tests. Ships with 10 reference CLIs (Reddit, Booking.com, Pexels, etc.).

MIT licensed, Python 3.10+.