### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -251,7 +251,8 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [docker-pushrm](https://github.com/christian-korneck/docker-pushrm) - Push a readme to container registries.
 - [ctop](https://github.com/bcicen/ctop) - Top like interface for container metrics.
 - [decompose](https://github.com/s0rg/decompose) - Create connections graph for running docker containers.
-- [kool](https://github.com/kool-dev/kool) - Web development with containers made easy. 
+- [kool](https://github.com/kool-dev/kool) - Web development with containers made easy.
+- [mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS built on Apple's Containerization framework.
 
 ### Release
 


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is a Docker-compatible container CLI for macOS, built natively on Apple's Containerization framework.

- **Docker-compatible:** Drop-in replacement with familiar Docker commands
- **Native macOS:** Built with Swift on Apple's Containerization framework (no VM overhead)
- **Open source:** Licensed under AGPL-3.0

Added to the Docker section.