### PR TITLE
Add promptdiff — semantic diff, lint, and score for LLM prompts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
+- [promptdiff](https://github.com/HadiFrt20/promptdiff) - Semantic diff, lint, and score for LLM prompt files.
 
 ### Text Editors
 


### PR DESCRIPTION
## Description

Adds [promptdiff](https://github.com/HadiFrt20/promptdiff) to the **Development** section.

**promptdiff** is a CLI tool for semantic diffing, linting, and scoring LLM prompt files. It helps developers compare prompt versions with analysis of tone, intent, and clarity changes.

- Open source on GitHub
- Installable via pip
- Fits the Development section as a developer-facing CLI utility