### PR TITLE
Add screencli: AI-driven browser screen recorder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -787,6 +787,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
 - [Shep](https://github.com/shep-ai/cli) - Multi-session SDLC control center for AI coding agents.
+- [screencli](https://github.com/usefulagents/screencli) - AI-driven browser screen recorder with auto-zoom, click highlights, and shareable links.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adds [screencli](https://github.com/usefulagents/screencli) to the AI > Agents section.

**What it does:** CLI that gives AI agents a screen recorder. One command records a browser session with auto-zoom, click highlights, gradient backgrounds, and outputs a shareable link.

**Install:** `npx screencli record https://your-app.com -p "your prompt"`

**Category:** AI > Agents (it's an agent-driven tool — the AI navigates the browser, screencli records the session)