### PR TITLE
Add admirarr — unified CLI for *Arr fleet (Radarr/Sonarr/Prowlarr/Jellyfin)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Movies
 
+- [admirarr](https://github.com/maxtechera/admirarr) - Unified CLI for your *Arr fleet (Radarr, Sonarr, Prowlarr, Jellyfin, qBittorrent). Deploy, diagnose, and operate self-hosted media stacks from one terminal.
 - [moviemon](https://github.com/iCHAIT/moviemon) - Everything about your movies.
 - [movie](https://github.com/mayankchd/movie) - Get movie info or compare movies.
 


### PR DESCRIPTION
## What is admirarr?

[admirarr](https://github.com/maxtechera/admirarr) is a zero-dependency CLI for managing a self-hosted Jellyfin/Plex + \*Arr media stack.

**Why it belongs here:**
- CLI tool (single Go binary, zero deps)
- 26 commands: `status`, `doctor`, `setup`, `add-movie`, `add-show`, `search`, `downloads`, `queue`, `missing`, `indexers`, `restart`, `logs`
- Covers the media stack management category (Movies/TV/self-hosted)
- JSON output everywhere for shell composition

**Quick demo:**
```bash
curl -fsSL https://get.admirarr.dev | sh
admirarr status     # fleet dashboard
admirarr doctor     # 34 diagnostic checks
```

Added under **Entertainment > Movies** section — it manages the tools that run your movie/TV library.

Repo: https://github.com/maxtechera/admirarr