### PR TITLE
Add penurie.net - French gas station prices via curl

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets.
 - [trino](https://github.com/eneserdogan/trino) - Translation of words and phrases.
 - [translate-shell](https://github.com/soimort/translate-shell) - Google Translate interface.
+- [penurie.net](https://penurie.net) - French gas station fuel prices and shortages, queryable via curl or browser.
 
 ### Internet Speedtest
 


### PR DESCRIPTION
<!---
Thank you for your pull request.
Please check the contribution guidelines for what is required of the app and this PR.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://penurie.net

**Description:**   
Follows the curl-first philosophy — no install, no account needed:

    curl penurie.net/paris

Returns plain text in terminal, HTML in browser.   
Data from French government open data (XML feed), refreshed every 10 min. 
```
⛽ penurie.net
3 station(s) — ville « paris »  [SP95]  (trié par MAJ récente)
Données mises à jour à 01:20
Station     Adresse                    SP95       MAJ
Oil France  8,10,10bis Rue Bailleul    ▲ 2.340 💶  27/03 14:23 (11h)
ENI         4 AVENUE FOCH              2.149 🥇    27/03 07:00 (18h)
Avia        1 Boulevard de la Chapell  2.199      24/03 06:09 (3j)
```

**Why I think it's awesome:**   
Nothing like it exists for France. "Pénurie" means shortage in French — the site was born during the 2022 fuel shortage crisis to help people quickly find stations with available fuel.

