### PR TITLE
Add PATAPIM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -787,6 +787,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
 - [Shep](https://github.com/shep-ai/cli) - Multi-session SDLC control center for AI coding agents.
+- [PATAPIM](https://patapim.ai) - Terminal IDE with 9-terminal grid, state detection, voice dictation, and MCP browser for AI coding agents.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
[PATAPIM](https://patapim.ai) is a terminal IDE for AI coding agents featuring a 9-terminal grid, agent state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser.

Added to the **AI > Agents** section alongside other agent management tools like agent-of-empires and Shep.

- **Platform:** Windows (macOS coming soon)
- **Built with:** Electron, xterm.js, node-pty
- **Pricing:** Freemium (Free tier + Pro $7/mo)