### PR TITLE
Add Admirarr — unified CLI for Jellyfin/Plex + *Arr media stacks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Movies
 
+- [Admirarr](https://github.com/maxtechera/admirarr) - Unified CLI for Jellyfin/Plex + *Arr stacks (Radarr, Sonarr, Prowlarr, qBittorrent). Deploy, diagnose, and operate your media fleet.
 - [moviemon](https://github.com/iCHAIT/moviemon) - Everything about your movies.
 - [movie](https://github.com/mayankchd/movie) - Get movie info or compare movies.
 


### PR DESCRIPTION
## What is Admirarr?

[Admirarr](https://github.com/maxtechera/admirarr) is a unified CLI for Jellyfin/Plex + \*Arr media server stacks.

**One binary, 26 commands, JSON output everywhere.** Deploy, configure, diagnose, and operate your entire fleet from a single terminal.

### Why it belongs in the Movies section

The Movies section covers CLI tools for managing and interacting with movie content. Admirarr unifies management of Radarr (movies), Sonarr (TV), Jellyfin/Plex (streaming), and their supporting services — all from one CLI.

### Key capabilities
- `admirarr setup` — Zero to media server in 15 minutes (12-phase automated deployment)
- `admirarr doctor` — 15 diagnostic categories, 34 checks, AI-powered repair suggestions
- `admirarr status` — Fleet dashboard with live TUI mode
- `admirarr missing` — Find missing movies across Radarr with quality filters
- Covers Jellyfin, Plex, Radarr, Sonarr, Prowlarr, qBittorrent, and 14+ optional services
- Single static binary, zero runtime dependencies
- MIT licensed, actively maintained

### Install
```bash
curl -fsSL https://get.admirarr.dev | sh
```

- **Repo**: https://github.com/maxtechera/admirarr
- **License**: MIT
- **Language**: Go (single binary)