### PR TITLE
Add reserve CLI toolbox to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -358,6 +358,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [cointop](https://github.com/miguelmota/cointop) - Track cryptocurrencies.
 - [ticker](https://github.com/achannarasappa/ticker) - Stock ticker.
 - [lakshmi](https://github.com/sarvjeets/lakshmi) - Bogleheads inspired tool for managing your investing portfolio.
+- [reserve](https://github.com/derickschaefer/reserve) - CLI toolbox for querying, analyzing, and automating workflows with Federal Reserve (FRED) macroeconomic data.
 
 ### Presentations
 


### PR DESCRIPTION
Hi! Adding **reserve**, a CLI toolbox for working with Federal Reserve (FRED) macroeconomic data.

It allows querying, analyzing, and automating workflows with FRED datasets from the command line.

Repo: https://github.com/derickschaefer/reserve

Happy to adjust the description or placement if needed. Thanks!

<!---
Thank you for your pull request.
Please check the contribution guidelines for what is required of the app and this PR.
-->

#### New App Submission

- [ ] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

**Description:**

**Why I think it's awesome:**

