### PR TITLE
Add InkOS to AI > Agents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -787,7 +787,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Dashboard for managing multiple AI coding agent sessions.
 - [Sugar](https://github.com/roboticforce/sugar) - Autonomous agent that queues and executes tasks in the background.
 - [Shep](https://github.com/shep-ai/cli) - Multi-session SDLC control center for AI coding agents.
-- [InkOS](https://github.com/Narcooo/inkos) - Autonomous novel-writing agent with 10-agent pipeline and continuity auditing.
+- [InkOS](https://github.com/Narcooo/inkos/blob/master/README.en.md) - Novel-writing agent.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/Narcooo/inkos

**Description:** InkOS is an autonomous novel-writing CLI agent powered by a 10-agent collaborative pipeline. It features 33-dimension continuity auditing, anti-AI-slop filtering, style cloning, cross-chapter repetition detection, and dialogue-driven narrative guidance. Built with Node.js/TypeScript, MIT licensed, 2.4k+ GitHub stars.

**Why I think it's awesome:** InkOS pushes the boundary of what AI agents can do autonomously — it doesn't just generate text, it orchestrates 10 specialized agents (planner, writer, auditor, etc.) to produce novel-length fiction with consistent characters, plot threads, and style. The 33-dimension audit system catches continuity errors that even human authors miss. It's a unique CLI tool in the AI agent space that focuses on creative writing rather than coding.