### PR TITLE
Add infynon CLI to security tools list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -473,6 +473,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gopass](https://github.com/gopasspw/gopass) - Fully-featured password manager.
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN.
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
+- [infynon](https://github.com/d4rkNinja/infynon-cli) - Security-first CLI: CVE firewall for 14 package ecosystems, reverse proxy WAF, and API flow tester with built-in security probes.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
 
 ### Math


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/d4rkNinja/infynon-cli
https://cli.infynon.com/docs

**Description:**
Security-first CLI with a CVE firewall for 14 package ecosystems, reverse proxy WAF with real-time TUI dashboard, and API flow tester with built-in security probes.

**Why I think it's awesome:**
Most security tools are dashboards you check after the fact. INFYNON sits *before* execution — it intercepts package installs across npm, pip, cargo, go, gem and 11 other ecosystems, scans CVEs via OSV.dev before anything touches disk, and blocks or auto-fixes vulnerable packages. It also ships a self-hosted reverse proxy WAF and an API flow tester in the same binary. Especially relevant now that AI coding agents (Claude Code, Cursor, Copilot) install packages autonomously without any security checks.