### PR TITLE
Add swipic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -726,6 +726,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [pageres-cli](https://github.com/sindresorhus/pageres-cli) - Capture website screenshots.
 - [optimizt](https://github.com/343dev/optimizt) - Helps prepare images for the web.
 - [freeze](https://github.com/charmbracelet/freeze) - Generate images of code and terminal output.
+- [swipic](https://github.com/javipd/swipic) - Tinder-style photo cleaner for macOS Photos.app.
 
 ### Gif Creation
 


### PR DESCRIPTION
[swipic](https://github.com/javipd/swipic) — Tinder-style photo cleaner for macOS Photos.app.

Swipe through your Photos.app library with arrow keys to keep or delete photos. Supports RAW formats, shows edited versions, batch delete with single macOS confirmation.

- Open source (MIT)
- Install: `pipx install swipic`
- PyPI: https://pypi.org/project/swipic/