### PR TITLE
Add prt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -420,6 +420,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gg](https://github.com/mzz2017/gg) - One-click proxy without installing v2ray or anything else.
 - [rustnet](https://github.com/domcyrus/rustnet) - Network monitoring with process identification and deep packet inspection.
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Transparent proxy server that works as a poor man's VPN.
+- [prt](https://github.com/rekurt/prt) - Real-time network port monitoring with change tracking, alerts, and process trees.
 
 ### Theming and Customization
 


### PR DESCRIPTION
**Repo:** https://github.com/rekurt/prt

**Description:** Real-time terminal UI for monitoring network ports — an interactive alternative to lsof/ss/netstat with change tracking, alerts, firewall blocking, and container awareness.

**Why it's awesome:**
prt replaces the workflow of repeatedly running `lsof -i` or `ss -tlnp` with a live, auto-refreshing TUI that tracks connection changes in real time. It combines port monitoring with features usually requiring multiple separate tools: suspicious connection detection, firewall blocking, strace attach, SSH tunnels, Docker container awareness, and configurable alerts — all accessible with single keypresses. Built in Rust with ratatui, cross-platform (macOS + Linux), multilingual (EN/RU/ZH).

Install: `cargo install prt`