### PR TITLE
Add Uni-CLI to AI > Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -794,6 +794,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [InkOS](https://github.com/Narcooo/inkos/blob/master/README.en.md) - Novel-writing agent.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal interface for AI agents to control 167 websites, 28 desktop apps, and 8 Electron apps. Self-repairing YAML adapters, structured JSON output, ~80 tokens per call.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adds [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) to the AI > Agents section.

Uni-CLI is a universal CLI that gives AI agents control over 167 websites, 28 desktop apps, and 8 Electron apps through a single `unicli <site> <command>` interface. Key features:

- Structured JSON output when piped — zero flags needed
- Self-repairing ~20 line YAML adapters
- ~80 tokens per invocation
- Apache-2.0, TypeScript, Node.js ≥ 20

`npm install -g @zenalexa/unicli`