### PR TITLE
Add grug-cli to Development section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
+- [grug-cli](https://github.com/grug-group420/grug-cli) - Zero-dependency developer toolkit following grug-brained principles. Simple, fast, no node_modules.
 
 ### Text Editors
 


### PR DESCRIPTION
Adding [grug-cli](https://github.com/grug-group420/grug-cli) - a zero-dependency developer toolkit that follows the grug-brained philosophy.

## Why it belongs here

- **Zero dependencies** - No node_modules, no npm install waiting
- **Fast startup** - Pure Bun.js, instant execution
- **Simple commands** - Project scaffolding, dev server, deployment tools
- **Philosophy-driven** - Based on 'The Grug Brained Developer' principles

Built with Bun.js for developers who prefer simplicity over complexity. 🪨