### PR TITLE
Add in-cli to Shell Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -795,6 +795,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
+- [resume-cli](https://github.com/inevolin/resume-cli) - TUI to resume AI coding sessions across Claude Code, GitHub Copilot CLI, and Codex from a single interactive picker; supports cross-tool context loading.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.

--- a/readme.md
+++ b/readme.md
@@ -443,6 +443,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets.
 - [envio](https://github.com/envio-cli/envio) - Manage environment variables securely.
 - [await](https://github.com/slavaGanzin/await) - Runs commands in parallel and waits for their termination.
+- [in-cli](https://github.com/inevolin/in-cli) - Execute shell commands across multiple directories sequentially or in parallel.
 - [aha](https://github.com/theZiz/aha) - Convert ANSI output to HTML.
 
 ### System Interaction Utilities


### PR DESCRIPTION
## Summary
- add in-cli to the Shell Utilities section
- describe it as a tool for running commands across multiple directories sequentially or in parallel

## Why
in-cli is a lightweight shell utility for batch command execution across multiple directories, which fits this list's shell tooling category.