### PR TITLE
Add cicada to AI > Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -793,6 +793,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [Shep](https://github.com/shep-ai/cli) - Multi-session SDLC control center for AI coding agents.
 - [InkOS](https://github.com/Narcooo/inkos/blob/master/README.en.md) - Novel-writing agent.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
+- [cicada](https://github.com/lewiswigmore/cicada) - Multi-agent orchestrator for GitHub Copilot CLI with MCP coordination.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 


### PR DESCRIPTION
Adds [cicada](https://github.com/lewiswigmore/cicada) to the **AI > Agents** section.

Cicada is a multi-agent orchestrator for GitHub Copilot CLI. It launches a team of AI agents (PM, Engineer, Reviewer, Tester) in Windows Terminal that collaborate through an MCP coordination server with messaging, a shared task board, and role management.

- PowerShell + Python
- Designed for GitHub Copilot CLI
- Open source (MIT)