### PR TITLE
Add httptap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -302,7 +302,17 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [Step CI](https://github.com/stepci/stepci) - API testing and QA framework.
 - [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
 - [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
-- [httptap](https://github.com/ozeranskii/httptap) - HTTP request visualizer with DNS, TCP, TLS, and TTFB phase timings rendered as a waterfall.
+- [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
+- [httptap](https://github.com/ozeranskii/httptap) - Breakdown and visualize HTTP requests. 
+
+### Testing
+
+- [shellspec](https://github.com/shellspec/shellspec) - A full-featured BDD unit-testing framework for all POSIX shells.
+- [gdb-dashboard](https://github.com/cyrus-and/gdb-dashboard) - Modular visual interface for GDB.
+- [loadtest](https://github.com/alexfernandez/loadtest) - Run load tests.
+- [Step CI](https://github.com/stepci/stepci) - API testing and QA framework.
+- [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
+- [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
 
 ## Productivity
 

--- a/readme.md
+++ b/readme.md
@@ -293,6 +293,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [ain](https://github.com/jonaslu/ain) - HTTP client with a simple format to organize API endpoints.
 - [curlie](https://github.com/rs/curlie) - A curl frontend with the ease of use of HTTPie.
 - [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
+- [httptap](https://github.com/ozeranskii/httptap) - Breakdown and visualize HTTP requests. 
 
 ### Testing
 

--- a/readme.md
+++ b/readme.md
@@ -302,6 +302,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [Step CI](https://github.com/stepci/stepci) - API testing and QA framework.
 - [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
 - [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
+- [httptap](https://github.com/ozeranskii/httptap) - HTTP request visualizer with DNS, TCP, TLS, and TTFB phase timings rendered as a waterfall.
 
 ## Productivity
 

--- a/readme.md
+++ b/readme.md
@@ -303,18 +303,6 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [Step CI](https://github.com/stepci/stepci) - API testing and QA framework.
 - [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
 - [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
-- [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
-- [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
-- [httptap](https://github.com/ozeranskii/httptap) - Breakdown and visualize HTTP requests. 
-
-### Testing
-
-- [shellspec](https://github.com/shellspec/shellspec) - A full-featured BDD unit-testing framework for all POSIX shells.
-- [gdb-dashboard](https://github.com/cyrus-and/gdb-dashboard) - Modular visual interface for GDB.
-- [loadtest](https://github.com/alexfernandez/loadtest) - Run load tests.
-- [Step CI](https://github.com/stepci/stepci) - API testing and QA framework.
-- [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
-- [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
 
 ## Productivity
 

--- a/readme.md
+++ b/readme.md
@@ -303,6 +303,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
 - [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
 - [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
+- [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust.
 - [httptap](https://github.com/ozeranskii/httptap) - Breakdown and visualize HTTP requests. 
 
 ### Testing


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/ozeranskii/httptap

**Description:**

HTTP request visualizer with DNS, TCP, TLS, and TTFB phase timings rendered as a waterfall.

**Why I think it's awesome:**

httptap answers the single question every developer eventually asks about a slow endpoint: *where is the time going?* It breaks one HTTP request into five phases (DNS, TCP connect, TLS handshake, server wait, body transfer) and prints them as a Rich-rendered waterfall, a compact single-line summary, or machine-readable key=value metrics — whichever fits the context. It follows redirect chains with per-step timing, reports TLS certificate details (CN, expiry, cipher), and accepts curl-compatible flags (`-X`, `-L`, `-k`, `-x`, `-H`) so it drops into existing scripts. Installs cleanly via `pip`, `uv`, `pipx`, or Homebrew with zero system dependencies; releases carry SLSA build provenance and the project holds OpenSSF Best Practices silver. Open-source under Apache-2.0, actively maintained, and documented at https://docs.httptap.dev.

Meets all contribution requirements:
- ✅ Does one thing (per-phase HTTP timing) well
- ✅ Apache-2.0 license
- ✅ Installable via pip / uv / pipx / brew
- ✅ Full docs at https://docs.httptap.dev
- ✅ Older than 90 days (created 2025-10-22)
- ✅ 485+ stars