### PR TITLE
Add lifeos-cli to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -319,6 +319,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [CookCLI](https://github.com/cooklang/CookCLI) - Full-featured recipe manager.
 - [hns](https://github.com/primaprashant/hns) - Speech-to-text tool to transcribe voice from microphone.
 - [mynav](https://github.com/GianlucaP106/mynav) - Workspace and session management TUI.
+- [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli) - Terminal-native LifeOS for personal workflows, habits, and timelogs.
 
 ### Time Tracking
 


### PR DESCRIPTION
## Summary
Add [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli), a terminal-native LifeOS for managing personal workflows, intentions, habits, and timelogs with agent-friendly interface.