### PR TITLE
Add taskdog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -348,6 +348,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [rucola](https://github.com/Linus-Mussmaecher/rucola) - Manage your markdown notes.
 - [kanban.bash](https://github.com/coderofsalvation/kanban.bash) - Kanban todo manager with a CSV backend.
 - [kanban](https://github.com/fulsomenko/kanban) - Keyboard-driven project management tool inspired by lazygit.
+- [taskdog](https://github.com/Kohei-Wada/taskdog) - Local-first task management with schedule optimization, time tracking, and dependency handling.
 
 ### Finance
 


### PR DESCRIPTION
Add [taskdog](https://github.com/Kohei-Wada/taskdog) to the Note Taking and Lists section.

Taskdog is a local-first task management system with schedule optimization, time tracking, and dependency handling.