### PR TITLE
Add gh-dep-risk under GitHub

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -715,6 +715,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 ### GitHub
 
 - [CLI GitHub](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
+- [gh-dep-risk](https://github.com/rad1092/gh-dep-risk) - On-demand npm dependency pull request risk review for GitHub.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
 


### PR DESCRIPTION
## Summary
- add `gh-dep-risk` under the GitHub section

## Why
- `gh-dep-risk` is a GitHub CLI extension for on-demand npm dependency pull request risk review
- it fits the GitHub subsection of the list
