### PR TITLE
Add SwarmClaw to AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -797,6 +797,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
+- [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime with MCP client and server support, 23+ LLM providers, persistent memory, skills, schedules, and messaging connectors.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
[SwarmClaw](https://github.com/swarmclawai/swarmclaw) is an open-source, self-hosted multi-agent CLI and runtime with MCP client and server support, 23+ LLM providers (Claude, GPT, Gemini, Ollama), persistent memory, skills, schedules, sub-agent spawning, and connectors for Discord, Slack, Telegram, WhatsApp, Teams, and Matrix. Also ships as Electron desktop app and Docker. MIT licensed, 358 stars.