### PR TITLE
Add changegen - Generate changelogs from git history

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 ### Release
 
 - [release-it](https://github.com/webpro/release-it) - Automate releases for Git repositories and/or npm packages. Changelog generation, GitHub/GitLab releases, etc.
+- [changegen](https://github.com/creativengine-ai/changegen) - Generate clean, categorized changelogs from git commit history using Conventional Commits.
 - [clog](https://github.com/clog-tool/clog-cli) - A conventional changelog for the rest of us.
 - [np](https://github.com/sindresorhus/np) - A better `npm publish`.
 - [release](https://github.com/vercel/release) - Generate changelogs with a single command.


### PR DESCRIPTION
## What does this PR add?

Adds [changegen](https://github.com/creativengine-ai/changegen) to the Release section.

`changegen` is a CLI tool that generates clean, categorized changelogs from git commit history using [Conventional Commits](https://www.conventionalcommits.org/). It reads git history since the latest tag, prints a colorized summary to the terminal, and writes `CHANGELOG.md`.

- Available on npm as `@creativengine-ai/changegen`
- Works with `npx @creativengine-ai/changegen` — no install needed
- Supports conventional commit categories (feat, fix, chore, etc.)