### PR TITLE
Add branch-watch — GitHub branch & fork sync status CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -717,6 +717,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [CLI GitHub](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
+- [branch-watch](https://github.com/nuri-yoo/branch-watch) - Track branch and fork sync status across your GitHub repositories.
 
 ### Emoji
 


### PR DESCRIPTION
## Description

Add [branch-watch](https://github.com/nuri-yoo/branch-watch) to the GitHub section.

`branch-watch` (`bw`) is a fast CLI tool that shows — at a glance — whether your GitHub branches are behind `main`, how far your forks have drifted from upstream, and what pull requests are open. No local clone required; queries the GitHub REST API directly.

**Key features:**
- `bw forks` — lists all forked repos vs. upstream with behind/ahead counts
- `bw branches owner/repo` — shows every branch vs. default branch
- `bw prs owner/repo` — lists open PRs with age
- `--behind-only` filter, `--json` output for scripting
- Available via `cargo install`, `pip install`, `npm install -g`, and Homebrew