### PR TITLE
Add issue-dash — self-hosted GitHub Issues dashboard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -717,6 +717,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [CLI GitHub](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
+- [issue-dash](https://github.com/GiulioSavini/issue-dash) - Self-hosted GitHub Issues dashboard with AI triage suggestions and CI failure analysis.
 
 ### Emoji
 


### PR DESCRIPTION
Adds [issue-dash](https://github.com/GiulioSavini/issue-dash) to the GitHub section.

It's a CLI + self-hosted dashboard that generates a prioritized HTML view of GitHub Issues. Groups by urgency/triage/WIP, surfaces CI failures on your PRs, and generates AI bullet-point suggestions via GitHub Models (free, same token). Zero npm/JS build — pure Python.

```bash
REPO=owner/repo python3 dashboard.py --html out.html
```