### PR TITLE
Add grugbot420 to AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -795,6 +795,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
+- [grugbot420](https://github.com/grug-group420/grugbot420) - Neuromorphic cognitive engine in Julia for multi-model AI orchestration.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## Addition: grugbot420

**Repository:** https://github.com/grug-group420/grugbot420  
**Section:** AI > Agents  
**License:** MIT | **Language:** Julia

A neuromorphic cognitive engine for multi-model AI orchestration. Deploys domain-expert AI specimens through architectural configuration.