### PR TITLE
Add agent-shadow-brain to AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -797,6 +797,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
+- [agent-shadow-brain](https://github.com/theihtisham/agent-shadow-brain) - Background code analysis agent that watches your codebase and provides real-time insights.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adding [agent-shadow-brain](https://github.com/theihtisham/agent-shadow-brain) — a background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.

Open-source, published on [npm](https://www.npmjs.com/package/@theihtisham/agent-shadow-brain). Format matches existing entries in the AI > Agents section. Thanks!