### PR TITLE
Add devkit-cli to JSON section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -555,6 +555,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 
 ### JSON
 
+- [devkit-cli](https://github.com/Alphaanon/devkit-cli) - Swiss-army-knife CLI for developers: JSON formatting, UUID generation, hashing, base64, JWT decoding, regex testing, and more.
 - [jp](https://github.com/therealklanni/jp) - JSON parser.
 - [fx](https://github.com/antonmedv/fx) - Command-line JSON viewer.
 - [vj](https://github.com/busyloop/vj) - Makes JSON human readable.


### PR DESCRIPTION
## devkit-cli

A zero-dependency Swiss-army-knife CLI for developers with 18 utilities:

- JSON pretty-printing and validation
- UUID generation (v4)
- Hash computation (MD5, SHA-1, SHA-256, SHA-512)
- Base64 encoding/decoding
- Timestamp conversion (Unix ↔ ISO)
- JWT decoding
- Regex testing
- Secure password generation
- CSV to JSON conversion
- Quick HTTP server
- Port checking
- Environment variable viewing
- And more...

**Repo:** https://github.com/Alphaanon/devkit-cli
**Install:** `curl -sL https://alphaanon.github.io/devkit-cli/devkit.py -o devkit && chmod +x devkit`

Single Python file, no dependencies. Works on any system with Python 3.6+.