### PR TITLE
Add codesight to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -477,6 +477,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN.
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
+- [codesight](https://github.com/AvixoSec/codesight) - LLM-powered code review, bug detection and security analysis with CWE/OWASP mapping and multi-provider support.
 
 ### Math
 


### PR DESCRIPTION
Adds CodeSight, an MIT-licensed LLM-powered CLI for code review, bug detection and security analysis.

- GitHub: https://github.com/AvixoSec/codesight
- PyPI: https://pypi.org/project/codesight
- Docs: https://codesight.is-a.dev
- License: MIT

Works offline via Ollama. SARIF output. Multi-provider LLM support.