### PR TITLE
Add prompt-to-asset and unslop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -732,6 +732,8 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [optimizt](https://github.com/343dev/optimizt) - Helps prepare images for the web.
 - [freeze](https://github.com/charmbracelet/freeze) - Generate images of code and terminal output.
 
+- [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - Route image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, and more) through a single MCP server.
+
 ### Gif Creation
 
 - [gifgen](https://github.com/lukechilds/gifgen) - Simple high quality GIF encoding.
@@ -801,6 +803,8 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
+
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - Strip AI writing patterns from text output — removes filler phrases, passive hedges, and LLM tics.
 
 ## Other Resources
 


### PR DESCRIPTION
## Add `prompt-to-asset` and `unslop`

Two CLI tools for the AI section and Images section.

### prompt-to-asset

- **Repo**: https://github.com/MohamedAbdallah-14/prompt-to-asset
- **Install**: `npm install -g prompt-to-asset`
- **What it does**: Routes image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney, and more) through a single MCP server. Works as both a CLI tool and an MCP server, so you can call it from any MCP-compatible AI client.
- **Added to**: Images section

### unslop

- **Repo**: https://github.com/MohamedAbdallah-14/unslop
- **Install**: `npm install -g unslop`
- **What it does**: Strips AI writing patterns from text output — removes filler phrases, passive hedges, and LLM tics. Pipe any text through it to clean up AI-generated content before publishing or committing.
- **Added to**: AI > LLM Interaction section