### PR TITLE
Add Voidly CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -422,6 +422,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gg](https://github.com/mzz2017/gg) - One-click proxy without installing v2ray or anything else.
 - [rustnet](https://github.com/domcyrus/rustnet) - Network monitoring with process identification and deep packet inspection.
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Transparent proxy server that works as a poor man's VPN.
+- [Voidly CLI](https://github.com/voidly-ai/cli) - Query global internet censorship data and detect when domains are blocked in target countries.
 
 ### Theming and Customization
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/voidly-ai/cli (npm: https://www.npmjs.com/package/@voidly/cli)

**Description:** Query global internet censorship data and detect when domains are blocked in target countries.

**Why I think it's awesome:**

Voidly CLI is the first terminal tool for querying global internet censorship data. It exposes the Voidly censorship intelligence API (19.6M live OONI samples + 10-year historical archive across 119 countries) directly from your shell, and its non-zero exit codes make it useful in CI pipelines:

```sh
npx @voidly/cli check chat.openai.com CN     # exits 1 if blocked
npx @voidly/cli country IR
npx @voidly/cli incidents --country=RU --limit=10
```

Unique fit: there is no existing "censorship" CLI in the list. It complements existing network utilities like `is-reachable-cli` (reachability) and `sshuttle` (bypass) by answering a different question: "is this domain censored where my users actually live?"

- MIT licensed
- Pure Node.js 18+, single command, no install required (`npx`)
- Documented at https://github.com/voidly-ai/cli
- Backed by a public API at api.voidly.ai (no auth needed for the endpoints the CLI uses)

Note on the 30-day/20-star guideline: the package was published this week so it does not yet meet the age/popularity bar. I'm submitting now to get on your radar, and am happy to have the PR held until it does.