### PR TITLE
Add cmux-resurrect to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -320,6 +320,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [CookCLI](https://github.com/cooklang/CookCLI) - Full-featured recipe manager.
 - [hns](https://github.com/primaprashant/hns) - Speech-to-text tool to transcribe voice from microphone.
 - [mynav](https://github.com/GianlucaP106/mynav) - Workspace and session management TUI.
+- [cmux-resurrect](https://github.com/drolosoft/cmux-resurrect) - Save, restore, and template terminal workspaces for tmux and Ghostty.
 
 ### Time Tracking
 


### PR DESCRIPTION
Add [cmux-resurrect](https://github.com/drolosoft/cmux-resurrect) (also known as crex) to the Productivity section.

**What it does:** Save, restore, and template terminal workspaces for tmux and Ghostty. Define layouts in TOML, restore them with one command.

- Workspace blueprints in TOML/Markdown
- Auto-detects tmux and Ghostty backends
- Save running sessions, restore across reboots
- Template gallery with starter layouts
- Shell completions (bash, zsh, fish)
- 21 GitHub stars, actively maintained
- MIT license, written in Go

Placed next to `mynav` (workspace and session management TUI) as they serve a similar use case.