### PR TITLE
Add KubeStellar Console

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [cronboard](https://github.com/antoniorodr/Cronboard) - Dashboard for managing cron jobs.
 - [s3m](https://github.com/s3m/s3m) - Stream of data into S3 buckets.
 - [bencher](https://github.com/bencherdev/bencher) - A continuous benchmarking tool.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability.
 
 ### Docker
 


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the Devops section.

KubeStellar Console is a multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability across edge and cloud clusters. It includes `kc-agent`, a CLI/MCP bridge for managing Kubernetes clusters from the terminal.

- Open source (Apache-2.0)
- Go + React/TypeScript
- CNCF KubeStellar ecosystem
- Installable via Homebrew, Docker, or Helm