### PR TITLE
Add tteg — stock photo search and download CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -731,6 +731,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [pageres-cli](https://github.com/sindresorhus/pageres-cli) - Capture website screenshots.
 - [optimizt](https://github.com/343dev/optimizt) - Helps prepare images for the web.
 - [freeze](https://github.com/charmbracelet/freeze) - Generate images of code and terminal output.
+- [tteg](https://github.com/kiluazen/tteg) - Search and download stock photos from Unsplash. No API key needed.
 
 ### Gif Creation
 


### PR DESCRIPTION
Adds [tteg](https://github.com/kiluazen/tteg) to the Images section.

tteg searches Unsplash and downloads stock photos to local files — no API key, no developer account. One command to replace placeholder images in a project.

```bash
uv tool install tteg
tteg save "startup office" ./public/hero --orientation landscape
```

[PyPI](https://pypi.org/project/tteg/) · MIT licensed