### PR TITLE
Add ci-doctor under Development > Linting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -818,3 +818,8 @@ Inclusion criteria are less strict for this fast-moving field.
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Adam Garrett-Harris](https://twitter.com/agarrharr) has waived all copyright and related or neighboring rights to this work.
+
+
+### Development > Linting
+
+* [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audits GitHub Actions workflows for cost, security, and reliability gaps. 16 rules. SARIF + PR comment via companion Action.

--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,8 @@ Expose a service running on localhost to the public web for testing and sharing.
 
 ### Devops
 
+* [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audits GitHub Actions workflows for cost, security, and reliability gaps. 16 rules, sister CLIs cover GitLab, Bitbucket, Azure Pipelines, CircleCI.
+
 - [htconvert](https://github.com/lukechilds/htconvert) - Convert .htaccess redirects to nginx.conf redirects.
 - [SAWS](https://github.com/donnemartin/saws) - Supercharged AWS CLI.
 - [s3cmd](https://github.com/s3tools/s3cmd) - Fully-Featured S3 client.
@@ -818,8 +820,3 @@ Inclusion criteria are less strict for this fast-moving field.
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Adam Garrett-Harris](https://twitter.com/agarrharr) has waived all copyright and related or neighboring rights to this work.
-
-
-### Development > Linting
-
-* [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audits GitHub Actions workflows for cost, security, and reliability gaps. 16 rules. SARIF + PR comment via companion Action.


### PR DESCRIPTION
### What this adds

> * [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audits GitHub Actions workflows for cost, security, and reliability gaps. 16 rules. SARIF + PR comment via companion Action.

### Why

ci-doctor is a free MIT-licensed CLI that audits GitHub Actions workflows for cost waste, security gaps (forked-PR pwn_request, unpinned actions, GITHUB_TOKEN write_all), and reliability issues (no timeout-minutes, missing concurrency:). It runs in <1s on most repos, uploads SARIF to GitHub Code Scanning via a companion Action, and posts a sticky PR comment.

It's actively maintained, has a sister CLI for every major CI provider (GitLab, Bitbucket, Azure Pipelines, CircleCI), and ships a public leaderboard scanning the top 100 actions/* repos.

### Conformance to the list

- Single-line entry in the requested section
- Verb-first description, trailing period
- Canonical repo URL as the link target

Happy to revise; ping me on this PR. Thanks for maintaining the list.