### PR TITLE
Add pdfmux to Files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -628,6 +628,8 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [scc](https://github.com/boyter/scc) - Count lines of code, blank lines, comment lines, and physical lines of source code.
 - [chkbit](https://laktak.github.io/chkbit/) - Check your files for data corruption.
 
+- [pdfmux](https://github.com/NameetP/pdfmux) - Universal PDF extraction CLI. Routes each page to the best of 5 backends (PyMuPDF, OpenDataLoader, RapidOCR, Docling) with optional BYOK LLM fallback. Per-page confidence scoring catches and re-extracts failures.
+
 ### File Sync/Sharing
 
 - [rclone](https://github.com/ncw/rclone) - Sync files with various cloud providers.


### PR DESCRIPTION
Adds [pdfmux](https://github.com/NameetP/pdfmux) (MIT) to the **Files** section.

**What it is:** Open-source PDF extraction CLI. Scores every page on 4 quality signals (text density, char distribution, structural coherence, OCR-comparison) and re-extracts low-confidence pages with a stronger backend.

**Why it fits Files section:** It's a CLI that processes PDF files — `pdfmux convert input.pdf > output.md` — sitting naturally alongside file-type-cli, bat, and other file utilities listed in this section.

**Proof points:**
- Ranks #2 on [opendataloader-bench](https://pdfmux.com/blog/benchmarking-pdf-extractors/) (200 real-world PDFs)
- Listed in [awesome-langchain](https://github.com/kyrolabs/awesome-langchain), [RAGHub](https://github.com/Andrew-Jang/RAGHub), [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) (85k★)
- MIT, pip install, runs locally

Happy to move to a different section (Productivity? Conversion?) if you'd prefer.