### PR TITLE
Add lean-ctx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -797,6 +797,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
+- [lean-ctx](https://github.com/yvgude/lean-ctx) - Context runtime for AI coding agents with MCP server and shell hook; reduces token costs through caching and compression.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.

--- a/readme.md
+++ b/readme.md
@@ -797,7 +797,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [coi](https://github.com/mensfeld/code-on-incus) - Incus container runtime for agents.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
-- [lean-ctx](https://github.com/yvgude/lean-ctx) - Context runtime for AI coding agents with MCP server and shell hook; reduces token costs through caching and compression.
+- [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/yvgude/lean-ctx

**Description:**

Context runtime for AI coding agents with MCP server and shell hook; reduces token costs through caching and compression.

**Why I think it's awesome:**

Apache-2.0, documented, easy install (`cargo install lean-ctx` or `npx lean-ctx-bin@latest`). One Rust binary with an MCP server and many tools focused on compressing and caching context for coding agents.
