### PR TITLE
Add spell to Shell Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -446,6 +446,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [envio](https://github.com/envio-cli/envio) - Manage environment variables securely.
 - [await](https://github.com/slavaGanzin/await) - Runs commands in parallel and waits for their termination.
 - [aha](https://github.com/theZiz/aha) - Convert ANSI output to HTML.
+- [spell](https://github.com/rockscy/spell) - Type a natural-language request, get a shell command to run, edit it inline, hit enter.
 
 ### System Interaction Utilities
 


### PR DESCRIPTION
Adds [spell](https://github.com/rockscy/spell) to the **Shell Utilities** section.

**spell** is a small Go CLI that turns a natural-language request into a shell command. The generated command lands in the same input box you typed your intent into, so you can edit it inline and hit \`enter\` to run. Single 7 MB binary, MIT licensed, no telemetry.

It works with any OpenAI-compatible or Anthropic-compatible provider, including local Ollama, so users aren't locked into one cloud vendor.

Description (one line):
> Type a natural-language request, get a shell command to run, edit it inline, hit enter.

Demo: 13-second GIF in the README.