### PR TITLE
Add Prosaic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Productivity](#productivity)
   - [Time Tracking](#time-tracking)
   - [Note Taking and Lists](#note-taking-and-lists)
+  - [Writing (Long-Form)](#writing-long-form)
   - [Finance](#finance)
   - [Presentations](#presentations)
   - [Calendars](#calendars)
@@ -349,6 +350,10 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [rucola](https://github.com/Linus-Mussmaecher/rucola) - Manage your markdown notes.
 - [kanban.bash](https://github.com/coderofsalvation/kanban.bash) - Kanban todo manager with a CSV backend.
 - [kanban](https://github.com/fulsomenko/kanban) - Keyboard-driven project management tool inspired by lazygit.
+
+### Writing (Long-Form)
+
+- [Prosaic](https://github.com/DimwitLabs/Prosaic) - A Git-friendly, writer-first app crafted for long-form writing.
 
 ### Finance
 


### PR DESCRIPTION
<!---
Thank you for your pull request.
Please check the contribution guidelines for what is required of the app and this PR.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** [prosaic.dimwit.me](https://prosaic.dimwit.me) | [DimwitLabs/Prosaic](https://github.com/DimwitLabs/Prosaic)

**Description:** Prosaic is a writer-first markdown-based writing app that is specialised and built for long-form writing in the terminal. It is Git-enabled, supports spell-check in about 80 languages, and offers quality-of-life features such as Focus mode, note-taking mode, and manuscript compilation for books. It also has anti-features, e.g. no AI, no distractions, no suggestions.

**Note:** I could not find a specific category, so I suggested a new category `Writing (Long-Form)`, but if you feel that the app still fits other categories like `Markdown` better, I'd be happy to move it.

**Why I think it's awesome:** There is no popular app yet that does long-form writing and caters to writers of prose rather than a general-purpose text editor on the list. I use it every day for my prose, and I built it with a lot of attention to the craft.

