### PR TITLE
Add rapidkit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -280,6 +280,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [boilr](https://github.com/tmrts/boilr) - Create projects from boilerplate templates.
 - [cookiecutter](https://github.com/audreyr/cookiecutter) - Create projects from templates.
 - [mevn-cli](https://github.com/madlabsinc/mevn-cli) - Light speed setup for MEVN (Mongo Express Vue Node) Apps.
+- [rapidkit](https://github.com/getrapidkit/rapidkit-npm) - Workspace platform CLI for scaffolding production-ready backend services with multi-runtime support (Python, Node.js, Java, Go) and 27+ modules.
 - [scaffold-static](https://github.com/jamesgeorge007/scaffold-static) - Scaffolding utility for vanilla JS.
 
 ### HTTP Server


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please check the contribution guidelines for what is required of the app and this PR.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/getrapidkit/rapidkit-npm

**Description:**
Workspace platform CLI for scaffolding production-ready backend services with multi-runtime support (Python, Node.js, Java, Go) and 27+ modules.

**Why I think it's awesome:**
rapidkit lets developers scaffold and manage full backend workspaces from the CLI — picking runtimes, modules, and configs interactively. It supports Python, Node.js, Java, and Go with production-ready templates and 27+ pluggable modules, making it a genuinely useful boilerplate tool for backend developers.