### PR TITLE
Add gitswitch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -712,6 +712,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [ggc](https://github.com/bmf-san/ggc) - A modern Git tool with both CLI and interactive incremental-search UI.
 - [AI Git Narrator](https://github.com/pmusolino/AI-Git-Narrator) - [macOS]: Generate commit messages with AI.
 - [gibr](https://github.com/ytreister/gibr) - Easily create consistent git branch names.
+- [gitswitch](https://github.com/target-ops/gitswitch) - Per-directory git identity binding with a pre-commit hook that refuses wrong-author commits.
 
 ### GitHub
 


### PR DESCRIPTION
Adding [gitswitch](https://github.com/target-ops/gitswitch) to the Git subsection.

```
- [gitswitch](https://github.com/target-ops/gitswitch) - Per-directory git identity binding with a pre-commit hook that refuses wrong-author commits.
```

## Submission checklist

- [x] Free and open source license (MIT)
- [x] More than 90 days old (created June 2024)
- [x] More than 20 GitHub stars
- [x] Description starts with capital letter and ends with period
- [x] No redundant info like "CLI"
- [x] Inserted at bottom of the `### Git` subsection (not alphabetical)
- [x] Single PR, one app

## What it does

Binds a git identity (`user.email`, `user.name`, signing key, `gh` account, SSH key) to a directory. After a one-time setup, every `cd` into the bound directory becomes the switch — no manual juggling. The killer feature is a pre-commit hook (`gitswitch guard`) that refuses commits where the active email doesn't match the directory's bound identity, so "I committed as the wrong person" becomes structurally impossible.

Single Go binary, ~2 MB, no runtime dependencies. macOS arm64/x64, Linux x64/arm64, Windows.
