### PR TITLE
Add agenttrace

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -799,6 +799,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Inspect AI coding agent sessions for cost, failures, latency, anomalies, and health gates.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## Summary
- Add agenttrace to the AI agents section.

## Notes
- agenttrace inspects local AI coding agent sessions for cost, failures, latency, anomalies, and health gates across tools like Claude Code, Codex CLI, Gemini CLI, Aider, and Cursor exports.
- The AI section notes that inclusion criteria are less strict for this fast-moving field.