### PR TITLE
Add nylas CLI under Productivity (email)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -312,6 +312,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [ffscreencast](https://github.com/cytopia/ffscreencast) - A ffmpeg screencast with video overlay and multi monitor support.
 - [meetup-cli](https://github.com/specious/meetup-cli) - Meetup.com client.
 - [NeoMutt](https://neomutt.org) - Email client.
+- [nylas](https://cli.nylas.com) - Send and read email from the terminal. Multi-provider (Gmail/Outlook/Exchange/Yahoo/iCloud/IMAP), one auth, JSON output for scripting, MCP server built in.
 - [terjira](https://github.com/keepcosmos/terjira) - Jira client.
 - [ipt](https://github.com/drselump14/ipt) - Pivotal Tracker client.
 - [uber-cli](https://github.com/jaebradley/uber-cli) - Uber client.


### PR DESCRIPTION
Adds **nylas** to the Productivity section, right after the existing **NeoMutt** email entry.

**What it is:** a CLI for email (and calendar, contacts) that handles all six major providers — Gmail, Outlook, Exchange, Yahoo, iCloud, IMAP — through a single auth flow. Outputs JSON for scripting, includes an MCP server, and works in shell scripts, GitHub Actions, cron jobs, and AI agent toolchains.

**Repo:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com

**Disclosure:** I work at Nylas. Happy to adjust the wording, section, or remove this PR if it doesn't fit.