### PR TITLE
Add Next.js and React shadcn/ui CLI boilerplate tools to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -281,6 +281,8 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [cookiecutter](https://github.com/audreyr/cookiecutter) - Create projects from templates.
 - [mevn-cli](https://github.com/madlabsinc/mevn-cli) - Light speed setup for MEVN (Mongo Express Vue Node) Apps.
 - [scaffold-static](https://github.com/jamesgeorge007/scaffold-static) - Scaffolding utility for vanilla JS.
+- [create-next-shadcn-kit](https://github.com/NikunjSonigara/create-next-shadcn-kit) - CLI to scaffold production-ready Next.js apps with shadcn/ui, Tailwind CSS, optional Redux/Zustand, and Husky preconfigured.
+- [create-react-shadcn-kit](https://github.com/NikunjSonigara/create-react-shadcn-kit) - CLI to scaffold React (Vite) apps with shadcn/ui, Tailwind CSS, Redux Toolkit, and Husky preconfigured.
 
 ### HTTP Server
 


### PR DESCRIPTION
Adds two CLI boilerplate tools for modern frontend development:

- create-next-shadcn-kit: Next.js scaffolding tool with shadcn/ui, Tailwind CSS, optional Redux/Zustand, and Husky.
- create-react-shadcn-kit: React (Vite) scaffolding tool with shadcn/ui, Tailwind CSS, Redux Toolkit, and Husky.

These tools help developers quickly bootstrap production-ready frontend projects.