### PR TITLE
Add Bernstein

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -799,6 +799,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Deterministic orchestrator for parallel CLI coding agents with git worktrees and signed audit logs.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adds Bernstein to AI > Agents.

It fits the existing entries in that subsection (agent-of-empires, agent-deck, Shep): a CLI tool that orchestrates multiple coding-agent sessions, with git worktrees for isolation. Open source (Apache-2.0), more than 90 days old, more than 20 stars, well documented.

Followed CONTRIBUTING.md: single app per PR, title `Add APP_NAME`, entry appended to the bottom of the AI > Agents subsection, no trailing whitespace, description with capital + period.