### PR TITLE
Add podfetch - podcast episode downloader/archiver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [radio-active](https://github.com/deep5050/radio-active) - Internet radio player with 40k+ stations.
 - [mpvc](https://github.com/gmt4/mpvc) - Music player interfacing mpv.
 - [TUISIC](https://github.com/Dark-Kernel/tuisic) - Login-free music streaming.
+- [podfetch](https://github.com/Kallbrig/podfetch) - Download and archive podcast episodes from RSS feeds.
 
 ### Video
 


### PR DESCRIPTION
## What is podfetch?

[podfetch](https://github.com/Kallbrig/podfetch) is a CLI tool to download and archive podcast episodes from an RSS feed.

**Features:**
- Resumable downloads via HTTP Range headers
- Progress bars with MB, %, speed, and ETA
- State tracking so re-runs skip already-downloaded episodes
- Graceful Ctrl+C handling
- Dry-run mode to preview episodes before downloading
- `--latest N` to grab only the most recent N episodes
- `--limit` and `--offset` for batch pagination

**Install:**
```
brew tap Kallbrig/podfetch
brew install podfetch
```

Added under `### Music` as there is no existing podcast section.