### PR TITLE
feat: add llm-prices to LLM Interaction section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -805,6 +805,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
 
+- [llm-prices](https://github.com/benbencodes/llm-prices) - Look up and compare LLM API costs across 60 models and 11 providers. Supports cost calculation, side-by-side comparison, and budget planning with Markdown/CSV export.
 ## Other Resources
 
 - [awesome-cli-apps-in-a-csv](https://github.com/toolleeo/awesome-cli-apps-in-a-csv) - Extensive list of CLI apps.


### PR DESCRIPTION
## Summary

Add [llm-prices](https://github.com/benbencodes/llm-prices) — a zero-dependency Python CLI for looking up and comparing LLM API pricing.

**What it does:**
- 60 models across 11 providers: OpenAI, Anthropic, Google, Together AI, Fireworks, Perplexity, Groq, Mistral, Cohere, DeepSeek, xAI
- `list`, `calc`, `compare`, `budget`, `providers` commands
- `--markdown` output (paste pricing tables into READMEs)
- `--csv` export
- No API key, no network calls — pricing baked in, works offline

**Example:**
```bash
$ llm-prices compare gpt-4o claude-sonnet-4-6 gemini-2.5-flash --in 5000 --out 1000
$ llm-prices budget 10.00 --in 2000 --out 500
$ llm-prices list --sort input --markdown
```

Fits under `### LLM Interaction` as a tool for developers working with LLM APIs who need to understand costs before committing to a provider.