### PR TITLE
Add prpack

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -714,6 +714,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [ggc](https://github.com/bmf-san/ggc) - A modern Git tool with both CLI and interactive incremental-search UI.
 - [AI Git Narrator](https://github.com/pmusolino/AI-Git-Narrator) - [macOS]: Generate commit messages with AI.
 - [gibr](https://github.com/ytreister/gibr) - Easily create consistent git branch names.
+- [prpack](https://github.com/Lucas2944/prpack) - Pack a pull request into one markdown file optimized for LLM code review.
 
 ### GitHub
 


### PR DESCRIPTION
Adding [prpack](https://github.com/Lucas2944/prpack) to the Git subsection.

prpack is a zero-dependency Node CLI (MIT) that packs a pull request into a single markdown file containing the diff and the full post-change content of every touched file. The output is sized and formatted to drop into Claude / Cursor / any LLM as code-review context.

```sh
npx github:Lucas2944/prpack --out ctx.md
```

Lives next to the other AI-adjacent git CLIs in the list (e.g. `AI Git Narrator`).

Checklist:
- [x] Hosted on GitHub with a README
- [x] License (MIT) visible in repo
- [x] Working install path (`npx github:Lucas2944/prpack`)
- [x] One short, descriptive line in the list, alphabetical-ish among recent additions