### PR TITLE
feat: add llm-prices to LLM Interaction section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -804,6 +804,7 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
+- [llm-prices](https://github.com/benbencodes/llm-prices) - Compare LLM API costs across 149 models and 22 providers. Find the cheapest model for your token budget, calculate job costs, and query pricing via MCP from Claude Code or Cursor.
 
 ## Other Resources
 


### PR DESCRIPTION
## What is this?

[llm-prices](https://github.com/benbencodes/llm-prices) is a zero-dependency Python CLI for comparing LLM API costs across providers.

## Why it belongs here

It fits the **AI → LLM Interaction** section — developers use it when choosing which LLM to call based on cost constraints.

**What it does:**
- Covers 149 models across 22 providers (OpenAI, Anthropic, Google, Mistral, xAI, DeepSeek, Groq, and more)
- `llm-prices top 10 --in 10000 --out 2000` — find the 10 cheapest models for a token budget
- `llm-prices compare gpt-4o claude-sonnet-4-6 gemini-2.5-flash` — side-by-side cost table
- `llm-prices calc gpt-4o --in 10000 --out 2000` — exact cost for a specific job
- `llm-prices list --json | jq` — JSON output for CI/scripts
- MCP server mode: query pricing from Claude Code or Cursor in natural language

**Checklist:**
- [x] Open-source (MIT)
- [x] Python CLI, zero runtime dependencies
- [x] Actively maintained (v0.1.26, updated weekly)
- [x] Fits "LLM Interaction" — choosing the right model is part of every LLM workflow
