### PR TITLE
Add dakera-cli to AI Agents — cross-platform Rust CLI for self-hosted agent memory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -799,6 +799,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [dakera-cli](https://github.com/dakera-ai/dakera-cli) - Cross-platform Rust CLI for managing a self-hosted Dakera AI agent memory server — start/stop server, manage namespaces, query memories, and configure decay policies.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## Summary

Adding [dakera-cli](https://github.com/dakera-ai/dakera-cli) to the **AI > Agents** section.

`dakera-cli` is the CLI companion for Dakera — a self-hosted AI agent memory server. It provides a developer-friendly terminal interface for managing the memory backend that AI agents use.

**What it does:**
- Start/stop/status the Dakera memory server
- Manage memory namespaces (create, list, configure)
- Query memories directly (search, inspect, forget)
- Configure decay policies and importance thresholds
- Manage sessions and view memory telemetry

**Why it belongs in this list:**
- Pure Rust binary, cross-platform (Linux/macOS/Windows)
- Stateless CLI design — no persistent daemon, connects to the server on demand
- Developer tool: makes it practical to work with agent memory in the terminal

The backing server ([dakera-mcp](https://github.com/dakera-ai/dakera-mcp)) scores 87.8% on the LoCoMo agent memory benchmark.