### PR TITLE
Add sharpe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -361,6 +361,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [moeda](https://github.com/thompsonemerson/moeda) - Foreign exchange rates and currency conversion.
 - [cash-cli](https://github.com/xxczaki/cash-cli) - Convert Currency Rates.
 - [cointop](https://github.com/miguelmota/cointop) - Track cryptocurrencies.
+- [sharpe](https://www.sharpe.ai/docs/cli) - Read crypto market state across funding, options, arbitrage, narratives, listings, and news.
 - [ticker](https://github.com/achannarasappa/ticker) - Stock ticker.
 - [lakshmi](https://github.com/sarvjeets/lakshmi) - Bogleheads inspired tool for managing your investing portfolio.
 


### PR DESCRIPTION
Adds `sharpe` to the Finance section.

This is a command-line app for reading crypto market state, including derivatives positioning, arbitrage, narrative rotation, exchange listings, and news. I placed it with finance/data tools such as `cointop` and `ticker`, and kept the entry in the repo's required style.

Disclosure: I work on Sharpe.