### PR TITLE
Add Dodo Payments CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [reachable](https://github.com/italolelis/reachable) - Check if a domain is up.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
+- [dodopayments-cli](https://github.com/dodopayments/dodopayments-cli) - Manage payments, subscriptions, customers and webhooks from your terminal, with an interactive TUI and a built-in AI assistant.
 
 ### Text Editors
 


### PR DESCRIPTION
Adding [Dodo Payments CLI](https://github.com/dodopayments/dodopayments-cli) to the **Development** section.

It is a command-line app for managing Dodo Payments resources (payments, subscriptions, customers, products, webhooks) from your terminal. Built in TypeScript/Bun, distributed via npm and standalone binaries for macOS/Linux/Windows. Features an interactive TUI, built-in AI assistant, and webhook tooling (live listen + offline trigger).

- Repo: https://github.com/dodopayments/dodopayments-cli
- npm: https://www.npmjs.com/package/dodopayments-cli
- License: GPL-3.0