### PR TITLE
Add rfx — fast local code search CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -679,6 +679,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [fd](https://github.com/sharkdp/fd) - A simple, fast and user-friendly alternative to `find`.
 - [broot](https://github.com/Canop/broot) - Fuzzy finder similar to fzf, but with space usage visualization.
 - [rare](https://github.com/zix99/rare) - Real-time regex aggregation and analysis.
+- [rfx](https://github.com/reflex-search/reflex) - Sub-100ms local full-text code search with trigram indexing. MCP server mode for AI coding agents, symbol extraction via tree-sitter, 18 languages.
 - [skim](https://github.com/lotabout/skim) - A general fuzzy finder written in Rust, similar to fzf.
 - [ast-grep](https://github.com/ast-grep/ast-grep) - A tool for code structural search, linting and rewriting.
 - [television](https://github.com/alexpasmantier/television) - A very fast general purpose fuzzy finder.


### PR DESCRIPTION
Adds `rfx` (Reflex) to the Search section.

**Repository:** https://github.com/reflex-search/reflex

**What it does:** Local full-text code search CLI using trigram indexing. Queries return in under
100ms on large codebases. Includes tree-sitter symbol extraction (18 languages), an MCP/HTTP
server mode for AI coding agent workflows, and incremental re-indexing on file changes.

**Why it fits awesome-cli-apps:**
- Pure CLI tool (`rfx query`, `rfx index`, `rfx serve`)
- Installable via `cargo install rfx` or `npm install -g reflex-search`
- Cross-platform, offline, no external dependencies at runtime

**Checklist:**
- [x] Entry placed in the Search section
- [x] Description is accurate and concise
- [x] Link points to the correct repository