### PR TITLE
Add transfa — ephemeral CLI file transfer for CI/CD and AI agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -646,6 +646,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [share](https://github.com/beavailable/share) - Share and receive files effortlessly over HTTP.
 - [shuk](https://shuk.rs) - Quicky share files using Amazon S3 buckets.
 - [croc](https://github.com/schollz/croc) - Easily send things from one computer to another.
+- [transfa](https://transfa.sh) - Upload any file from the CLI, get a SHA-256-verified, TTL-enforced link. Built for CI/CD pipelines and AI agents.
 
 ### Directory Listing
 


### PR DESCRIPTION
Adds [transfa](https://transfa.sh) to the File Sync/Sharing section.

**What it does:** Upload any file from the CLI with `tf upload file.tar.gz`, get back a SHA-256-verified, TTL-enforced download link. Designed for CI/CD pipelines and AI agents.

```sh
npm install -g transfa-cli
tf upload model.bin --ttl 24h
# → https://transfa.sh/f/abc123
```

- MIT licensed, open source
- GitHub: https://github.com/colapsis/transfa
- npm: https://www.npmjs.com/package/transfa-cli