### PR TITLE
Add embercore

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -802,6 +802,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [embercore](https://github.com/embercore-labs/embercore) - Plan-first AI marketing planner with a Go CLI, MCP server, named agents, and human approval checkpoints.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## Summary
- add embercore to the AI agents section

## Why it fits
embercore ships a Go CLI alongside an MCP server, uses named agents for a real workflow, and includes explicit human approval checkpoints before execution.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>