### PR TITLE
Add Octomind to AI > Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -802,6 +802,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [Octomind](https://github.com/muvon/octomind) - Open-source AI agent runtime in Rust with 48+ specialist agents, MCP host with dynamic registration, and multi-provider support (13+ LLMs).
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adds [Octomind](https://github.com/muvon/octomind) under AI > Agents.

**About:** Open-source AI agent runtime in Rust. Single binary, 48+ specialist agents (lawyer, doctor, engineer, DevOps, finance, security, etc.), MCP host with dynamic registration, multi-provider (13+ LLMs), adaptive context compression for 4+ hour sessions.

- Repo: https://github.com/muvon/octomind (Apache 2.0)
- Site: https://octomind.run
- Author: Muvon Un Limited

Inclusion criteria for AI section are stated as 'less strict for this fast-moving field', and the project fits the existing Agents subsection alongside greywall, agent-of-empires, Shep, etc.