### PR TITLE
Add say-it: pronunciation dictionary for project names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,6 +321,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [OverTime](https://github.com/diit/overtime-cli) - Time-overlap tables for remote teams.
 - [CookCLI](https://github.com/cooklang/CookCLI) - Full-featured recipe manager.
 - [hns](https://github.com/primaprashant/hns) - Speech-to-text tool to transcribe voice from microphone.
+- [say-it](https://github.com/anzy-renlab-ai/pronounce) - Speak project, product, and programmer-jargon names out loud the way engineers actually pronounce them. Community dictionary with creator citations (GIF → "jif" per Wilhite, kubectl → "koob control" per Hightower, ...).
 - [mynav](https://github.com/GianlucaP106/mynav) - Workspace and session management TUI.
 
 ### Time Tracking


### PR DESCRIPTION
Adds [say-it](https://github.com/anzy-renlab-ai/pronounce) — a tiny Bash CLI that wraps macOS `say` with a community-maintained dictionary of how engineers actually pronounce project / product / programmer-jargon names (kubectl, nginx, GIF, JSON, Pydantic, Knative, LaTeX, ~230 more).

Distinct from text-to-speech tools in this list: the value is the **dictionary** (sourced from creator interviews / official FAQs / Wikipedia) plus the CLI that surfaces multi-reading words via an audible "or: <alt>" tail.

- 🌐 Live demo: <https://pronounce.renlab.ai>
- ⭐ MIT, ~250 lines of Bash, zero dependencies
- 🤖 Ships with a Claude Code skill for AI-side pronunciation questions