### PR TITLE
Add say-it — pronunciation CLI for developer jargon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -403,6 +403,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [dark-mode](https://github.com/sindresorhus/dark-mode) - Toggle dark mode.
 - [clippy](https://github.com/neilberkman/clippy) - Clipboard tool for interacting with GUI applications.
 - [anvil](https://github.com/0xjuanma/anvil) - Config management and app installations.
+- [say-it](https://github.com/anzy-renlab-ai/pronounce) - Pronounce developer jargon out loud — 540+ cited entries (kubectl, GIF, JWT, …), audible alternates, MCP server, zero-dep Bash wrapping macOS `say`.
 
 ### Terminal Sharing Utilities
 


### PR DESCRIPTION
**Repo:** https://github.com/anzy-renlab-ai/pronounce
**Live demo:** https://pronounce.renlab.ai

`say-it` is a zero-dependency CLI that pronounces developer jargon — `kubectl` → "koob control", `GIF` → "jif", `JWT` → "jot" — out loud, using a 540-entry community dictionary with cited sources.

```
$ say-it kubectl
🔊  koob control. koob control. koob control. or: cube cuddle. or: kube C T L.
```

**Why it fits awesome-cli-apps → Utilities → macOS:**

- Pure Bash, wraps macOS `say`
- Every entry has a source URL (creator interview, project FAQ, RFC)
- Multi-reading words audibly chain alternates ("…or: gif")
- Ships a Claude Code skill, MCP server, and Raycast script command
- MIT licensed, community-contributed

Inserted at the end of `### macOS`.