### PR TITLE
Add Entroly to AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -804,6 +804,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [Entroly](https://github.com/juyterman1000/entroly) - Information-theoretic context optimizer and proxy that cuts LLM token costs by up to 95% for coding agents.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
This PR adds Entroly (context engineering engine/proxy for agents) under AI -> Agents.