### PR TITLE
Add warnely-cli to Browser Replacement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -510,6 +510,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets.
 - [trino](https://github.com/eneserdogan/trino) - Translation of words and phrases.
 - [translate-shell](https://github.com/soimort/translate-shell) - Google Translate interface.
+- [warnely-cli](https://github.com/sn-lui/warnely-cli) - Composite travel-safety scores for 180 countries from the Warnely Public API (CC BY 4.0). Single-file, zero deps.
 
 ### Internet Speedtest
 


### PR DESCRIPTION
Adds [warnely-cli](https://github.com/sn-lui/warnely-cli) under **Browser Replacement** (fits the same shape as wttr.in, nasa-cli, and getnews.tech).

## What it does

Composite travel-safety scores for 180 countries from the [Warnely Public API](https://warnely.com/developers). Combines UK FCDO + US State Department advisories, the Global Peace Index, World Bank Worldwide Governance Indicators, and a live news incident wire.

```
warnely TH                      # one country, full snapshot
warnely TH --short              # one-line summary
warnely list --region Asia      # all Asian countries, sorted
warnely incidents --country TH  # live wire filtered to Thailand
warnely methodology             # composite formula + sources
```

## Why it fits this list

- Single-file Python (stdlib only — zero dependencies)
- Replaces opening warnely.com/guides/is-X-safe in a browser
- TTY-aware colour, NO_COLOR respected, --json for piping
- Pipeable, scriptable, sensible exit codes
- CC BY 4.0 — commercial use allowed with attribution

`pip install "git+https://github.com/sn-lui/warnely-cli.git"`