### PR TITLE
feat: add llm-prices to LLM Interaction section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -804,6 +804,7 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
+- [llm-prices](https://github.com/benbencodes/llm-prices) - Compare LLM API costs across 149 models and 22 providers. Find the cheapest model for your token budget, calculate job costs, and query pricing via MCP from Claude Code or Cursor.
 
 ## Other Resources
 

--- a/readme.md
+++ b/readme.md
@@ -804,6 +804,7 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
+- [llm-prices](https://github.com/benbencodes/llm-prices) - Look up and compare LLM API pricing across 255 models and 43 providers. No API key required.
 - [llm-prices](https://github.com/benbencodes/llm-prices) - Compare LLM API costs across 149 models and 22 providers. Find the cheapest model for your token budget, calculate job costs, and query pricing via MCP from Claude Code or Cursor.
 
 ## Other Resources


### PR DESCRIPTION
## What this adds

[llm-prices](https://github.com/benbencodes/llm-prices) — a zero-dependency Python CLI for comparing LLM API pricing across providers.

**Why it fits here:**
- CLI tool in the AI / LLM Interaction category
- Lets developers quickly look up and compare API costs for 255 models across 43 providers (OpenAI, Anthropic, Google, Mistral, Groq, DeepSeek, xAI, Qwen, and 35 more)
- No API key required — pricing data is baked in, works offline
- Useful for anyone building with LLM APIs who needs to compare costs

**Example usage:**
```bash
pip install llm-prices
llm-prices list                          # browse all models with pricing
llm-prices calc gpt-4o 10000 5000       # cost for specific token counts
llm-prices compare o3 gpt-4.1 claude-sonnet-4-6  # side-by-side comparison
llm-prices budget 100.00 --in 1500 --out 300  # how many calls per $100
```

- [GitHub](https://github.com/benbencodes/llm-prices)
- License: MIT
- Language: Python
