### PR TITLE
Add luffy - CLI movie and TV streaming tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mpv](https://mpv.io) - Superior video player.
 - [editly](https://github.com/mifi/editly) - Declarative video editing.
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A `youtube-dl` fork with additional features and fixes.
+- [luffy](https://github.com/DemonKingSwarn/luffy) - Stream movies and TV shows in mpv/vlc with fuzzy search, watch history, and subtitle support.
 
 ### Movies
 


### PR DESCRIPTION
## luffy

- **GitHub**: https://github.com/DemonKingSwarn/luffy
- **Category**: Entertainment > Video

### Why it fits

Luffy is a terminal-based streaming client written in Go. It lets you search for movies and TV shows via fzf, resolves the stream URL locally, and opens it directly in mpv or vlc — no browser required.

**Key features:**
- Fuzzy search with fzf
- Quality selection from m3u8 playlists
- Native subtitle support
- Watch history with resume
- Next/Previous/Replay episode controls
- Download via yt-dlp
- Cross-platform (Linux, macOS, Windows, Android/Termux)

### Checklist
- [x] Added in the correct section (Entertainment > Video)
- [x] Alphabetical order maintained within section
- [x] Description is concise and clear
- [x] Link goes to the GitHub repo