### PR TITLE
Add citable: AI search visibility CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [strip-css-comments-cli](https://github.com/sindresorhus/strip-css-comments-cli) - Strip comments from CSS.
 - [viewport-list-cli](https://github.com/kevva/viewport-list-cli) - Return a list of devices and their viewports.
 - [surge](https://surge.sh) - Publish static websites for free.
-
+- [citable](https://github.com/WorkSmartAI-alt/citable) - Score your site for ChatGPT, Claude, Perplexity, and Google AI visibility. 15 checks, 5-sheet xlsx output.
 ### Public localhost
 
 Expose a service running on localhost to the public web for testing and sharing.


### PR DESCRIPTION
Adding [citable](https://github.com/WorkSmartAI-alt/citable), a free open-source CLI that audits websites for AI search visibility (ChatGPT, Claude, Perplexity) and SEO foundations.

- MIT licensed
- 15 checks across 6 categories
- 5-sheet xlsx output (Action Plan, Score Breakdown, Per-Page Detail, Action List, Summary)
- 60-second runtime

Added under Frontend Development since it audits website characteristics, alongside tools like surge and viewport-list-cli. Happy to move if a different category fits better.
