### PR TITLE
Add amazon-orders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -394,7 +394,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [clevercli](https://github.com/clevercli/clevercli) - Collection of ChatGPT powered utilities.
 - [OctoType](https://github.com/mahlquistj/octotype) - A customizable typing trainer.
 - [gittype](https://github.com/unhappychoice/gittype) - Turn your source code into typing challenges.
-- [amazon-orders](https://github.com/alexdlaird/amazon-orders) - Retrieve Amazon order history, line items, and transactions.
+- [amazon-orders](https://github.com/alexdlaird/amazon-orders) - Retrieve Amazon order history.
 
 ### macOS
 

--- a/readme.md
+++ b/readme.md
@@ -394,7 +394,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [clevercli](https://github.com/clevercli/clevercli) - Collection of ChatGPT powered utilities.
 - [OctoType](https://github.com/mahlquistj/octotype) - A customizable typing trainer.
 - [gittype](https://github.com/unhappychoice/gittype) - Turn your source code into typing challenges.
-- [amazon-orders](https://github.com/alexdlaird/amazon-orders) - Retrieve Amazon order history, line items, prices, and receipts.
+- [amazon-orders](https://github.com/alexdlaird/amazon-orders) - Retrieve Amazon order history, line items, and transactions.
 
 ### macOS
 

--- a/readme.md
+++ b/readme.md
@@ -394,6 +394,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [clevercli](https://github.com/clevercli/clevercli) - Collection of ChatGPT powered utilities.
 - [OctoType](https://github.com/mahlquistj/octotype) - A customizable typing trainer.
 - [gittype](https://github.com/unhappychoice/gittype) - Turn your source code into typing challenges.
+- [amazon-orders](https://github.com/alexdlaird/amazon-orders) - Retrieve Amazon order history, line items, prices, and receipts.
 
 ### macOS
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/alexdlaird/amazon-orders

**Description:** Retrieve Amazon order history, line items, and transactions.

**Why I think it's awesome:** There's no public Amazon orders API, so anyone exporting their purchases for taxes or budgeting has to scrape. amazon-orders does that cleanly.