### PR TITLE
Add ical

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -382,7 +382,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [vdirsyncer](https://github.com/pimutils/vdirsyncer) - CalDAV sync.
 - [remind](https://dianne.skoll.ca/projects/remind/) - A sophisticated calendar and alarm program.
 - [birthday](https://github.com/IonicaBizau/birthday) - Know when a friend's birthday is coming.
-- [ical](https://github.com/BRO3886/ical) - Manage macOS Calendar events with structured JSON output, recurrence, and ICS export.
+- [ical](https://github.com/BRO3886/ical) - Manage macOS Calendar.
 
 ## Utilities
 

--- a/readme.md
+++ b/readme.md
@@ -382,6 +382,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [vdirsyncer](https://github.com/pimutils/vdirsyncer) - CalDAV sync.
 - [remind](https://dianne.skoll.ca/projects/remind/) - A sophisticated calendar and alarm program.
 - [birthday](https://github.com/IonicaBizau/birthday) - Know when a friend's birthday is coming.
+- [ical](https://github.com/BRO3886/ical) - Manage macOS Calendar events with structured JSON output, recurrence, and ICS export.
 
 ## Utilities
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the contribution guidelines.

**Repo or homepage link:** https://github.com/BRO3886/ical

**Description:** Manage macOS Calendar events with structured JSON output, recurrence, and ICS export.

**Why I think it's awesome:** Native macOS Calendar access with structured JSON output designed for AI agents and shell pipelines — no CalDAV server or sync needed.
