### PR TITLE
Add linkedin2md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -528,6 +528,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 
 - [resumx](https://github.com/resumx/resumx) - Markdown resume renderer with auto page-fitting.
 - [YAMLResume](https://github.com/yamlresume/yamlresume) - Resumes as code.
+- [linkedin2md](https://github.com/juanmanueldaza/linkedin2md) - Convert LinkedIn data exports to Markdown for LLM analysis and PDF resume generation.
 
 ## Command Line Learning
 


### PR DESCRIPTION
## linkedin2md

**GitHub:** https://github.com/juanmanueldaza/linkedin2md  
**PyPI:** https://pypi.org/project/linkedin2md/

A zero-dependency Python CLI that converts LinkedIn ZIP data exports into clean, structured Markdown and ATS-optimized PDF resumes.

```bash
pip install linkedin2md
linkedin2md /path/to/linkedin_export.zip
```

- Does one thing well: LinkedIn data → Markdown + PDF
- Zero dependencies, no API keys, fully local
- Stars: 14 | PyPI downloads: 4,500+