### PR TITLE
feat: add longbridge-terminal (AI-native financial markets CLI)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -365,6 +365,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [cointop](https://github.com/miguelmota/cointop) - Track cryptocurrencies.
 - [ticker](https://github.com/achannarasappa/ticker) - Stock ticker.
 - [lakshmi](https://github.com/sarvjeets/lakshmi) - Bogleheads inspired tool for managing your investing portfolio.
+- [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) - AI-native CLI for Longbridge Securities: real-time quotes, portfolio, and trading for HK/US/A-share/SG markets.
 
 ### Presentations
 


### PR DESCRIPTION
## Description

Add [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) to the **Finance** section.

## What is longbridge-terminal?

An AI-native CLI for Longbridge Securities built in Rust. It provides real-time market data, portfolio management, and trading for HK / US / A-share / SG markets with a TUI dashboard.

- **Language**: Rust
- **Stars**: 837+
- **Repo**: https://github.com/longbridge/longbridge-terminal

## Checklist

- [x] Added to Finance section
- [x] Description is concise and accurate
- [x] Link is correct and points to the GitHub repo