### PR TITLE
Add gomarklint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -479,6 +479,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gtree](https://github.com/ddddddO/gtree) - Use markdown to generate directory trees and the directories itself.
 - [Jimmy](https://github.com/marph91/jimmy) - Convert various note formats to markdown.
 - [mq](https://github.com/harehare/mq) - Jq-like markdown processor.
+- [gomarklint](https://github.com/shinagawa-web/gomarklint) - Fast linter with link validation, single binary, no runtime required.
 
 ### Security
 


### PR DESCRIPTION
## gomarklint

https://github.com/shinagawa-web/gomarklint

Satisfies the submission criteria:

- **One thing done well**: Markdown linting with link validation
- **Open source**: MIT license
- **Easy to install**: `curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | sh`, also available via Homebrew and npm
- **Well documented**: https://shinagawa-web.github.io/gomarklint/
- **Older than 90 days**: first release March 2024
- **Stars**: 100+