### PR TITLE
Add boss-agent-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -811,6 +811,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin job search assistant for AI agents with structured JSON output, local shortlists, and MCP tools.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adds boss-agent-cli to the AI / Agents category. It is an open-source BOSS Zhipin job search assistant for AI agents, with structured JSON output, local shortlists, and MCP tools.\n\nValidation: ran git diff --check.