### PR TITLE
Add capcut-cli to Video

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mpv](https://mpv.io) - Superior video player.
 - [editly](https://github.com/mifi/editly) - Declarative video editing.
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A `youtube-dl` fork with additional features and fixes.
+- [capcut-cli](https://github.com/renezander030/capcut-cli) - Edit CapCut and JianYing video projects: subtitles, timing, templates, and cutting long videos into shorts.
 
 ### Movies
 


### PR DESCRIPTION
Adds [capcut-cli](https://github.com/renezander030/capcut-cli) to the **Video** section.

It edits CapCut and JianYing project files (`draft_content.json`) directly from the command line — subtitles, timing, speed, templates, auto-captioning, and cutting long-form into shorts. Zero runtime dependencies (Node ≥ 18), JSON in/out. Sits naturally next to `editly` (declarative video editing).

- Entry format follows contributing.md: capital start, period end, no "CLI"/"terminal" in the description.
- Single addition, Video section.