### PR TITLE
Add quokka: iPhone inspection and cleanup CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -408,6 +408,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [dark-mode](https://github.com/sindresorhus/dark-mode) - Toggle dark mode.
 - [clippy](https://github.com/neilberkman/clippy) - Clipboard tool for interacting with GUI applications.
 - [anvil](https://github.com/0xjuanma/anvil) - Config management and app installations.
+- [quokka](https://github.com/dutradotdev/quokka) - Inspect and clean up an iPhone over USB from the terminal. No jailbreak.
 
 ### Terminal Sharing Utilities
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).
**Repo or homepage link:** https://github.com/dutradotdev/quokka

**Description:** Inspect and clean up an iPhone over USB from the terminal. Apps, storage, syslog, duplicate media. macOS, no jailbreak.

**Why I think it's awesome:** Only terminal-native iPhone inspection tool for macOS. No jailbreak, no GUI, no tunnel daemon. Written in Rust with a TUI launcher.