### PR TITLE
Add tokenmap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -800,6 +800,8 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 ## AI
 Inclusion criteria are less strict for this fast-moving field.
 
+- [tokenmap](https://github.com/akshatshaw/tokenmap) - GitHub-style heatmap of your AI coding tool usage and costs.
+
 ### Agents
 - [greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default sandbox with filesystem and network isolation.
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - Coding agent session manager via tmux and git worktrees.


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/akshatshaw/tokenmap

**Description:**

A GitHub-style contribution heatmap that shows how much you actually use AI coding tools (Claude Code, Codex, OpenCode, Cursor), plus an estimated cost breakdown by model. One command, auto-detects installed tools, reads only local data, and can optionally export PNG/SVG/CSV. MIT licensed; `pip install tokenmap`.

**Why I think it's awesome:**

It turns the usage data already sitting on your machine into a single, shareable picture of your AI coding habits and spend — no config, no accounts, and nothing leaves your machine. I placed it under the AI section, whose relaxed inclusion criteria fit a tool this new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
