### PR TITLE
Add pisesh — pi coding-agent session bookmark/resume TUI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -812,6 +812,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [pisesh](https://github.com/Blue-B/pisesh) - Bookmark, search, and resume pi coding-agent sessions with a fast keyboard-driven TUI.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
[**pisesh**](https://github.com/Blue-B/pisesh) is a single-file zero-dependency Node TUI that adds favorites, search, and a `[NOW]` badge to the [pi coding-agent](https://github.com/earendil-works/pi) session resume picker. It also ships a pi extension that registers a `/sesh` slash command so you can call it from inside any pi session.

- npm: https://www.npmjs.com/package/pisesh
- MIT licensed
- CJK-aware width math (Korean/Chinese/Japanese prompts render correctly)
- Added under `## AI` → `### Agents` since it's a session manager for an AI coding agent (fits next to `agent-deck`, `Shep`, `agent-of-empires`).