### PR TITLE
Add mcp-video to Video

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mpv](https://mpv.io) - Superior video player.
 - [editly](https://github.com/mifi/editly) - Declarative video editing.
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A `youtube-dl` fork with additional features and fixes.
+- [mcp-video](https://github.com/KyaniteLabs/mcp-video) - Guardrailed FFmpeg video-editing CLI/MCP server for AI agents (uvx mcp-video).
 
 ### Movies
 


### PR DESCRIPTION
Adds mcp-video (KyaniteLabs/mcp-video) to the Video section — a guardrailed FFmpeg CLI/MCP server for AI agents.