### PR TITLE
Add Epoch to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -325,6 +325,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [hns](https://github.com/primaprashant/hns) - Speech-to-text tool to transcribe voice from microphone.
 - [mynav](https://github.com/GianlucaP106/mynav) - Workspace and session management TUI.
 - [linear-tui](https://github.com/roeyazroel/linear-tui) - Linear TUI client.
+- [Epoch](https://github.com/KyaniteLabs/Epoch) - Software estimation CLI: PERT, COCOMO II, Monte Carlo, schedule risk (npx @kyanitelabs/epoch).
 
 ### Time Tracking
 


### PR DESCRIPTION
Adds Epoch (KyaniteLabs/Epoch) to the Productivity section — a software estimation CLI: PERT, COCOMO II, Monte Carlo, schedule risk.