### PR TITLE
Add fuckssh to SSH section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -421,6 +421,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 
 - [mosh](https://mosh.org/) - Remote SSH client that allows roaming with intermittent connectivity.
 - [xxh](https://github.com/xxh/xxh) - Bring your favorite shell wherever you go through SSH.
+- [fuckssh](https://github.com/hczs/fuckssh) - SSH config manager: one-command key generation, public key deployment, and config writing.
 
 ### Network Utilities
 


### PR DESCRIPTION
## What

Add [fuckssh](https://github.com/hczs/fuckssh) to the SSH section.

## Why

fuckssh is a cross-platform CLI tool that automates SSH key generation, public key deployment, and SSH config writing. It's useful for developers who manage multiple VPS instances and want to streamline the SSH setup process.

Key features:
- One-command SSH setup (key gen + public key deploy + config write)
- List and search existing SSH hosts
- Edit and delete SSH config entries with auto-backup
- Only writes standard ~/.ssh/config (no proprietary format)
- Cross-platform: macOS, Linux, Windows

## Where

Added to the SSH section after xxh.