### PR TITLE
Add proof-of-commitment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [updates](https://github.com/silverwind/updates) - Flexible npm dependency update tool.
 - [wipe-modules](https://github.com/bntzio/wipe-modules) - Remove `node_modules` of inactive projects.
 - [npm-deprecated-check](https://github.com/KID-joker/npm-deprecated-check) - Check for deprecated dependencies.
+- [proof-of-commitment](https://github.com/piiiico/proof-of-commitment) - Audit supply chain risk in npm packages by scoring behavioral commitment signals.
 
 ### Boilerplate
 


### PR DESCRIPTION
## What

Adds [proof-of-commitment](https://github.com/piiiico/proof-of-commitment) to the **Npm** section.

```bash
npx proof-of-commitment
```

Zero-install CLI that audits supply chain risk in npm packages (and PyPI, Rust crates, Go modules). Scores packages on behavioral commitment signals — publisher count, transfer history, contributor concentration — that `npm audit` doesn't cover.

## Why it fits

- Works in any project: auto-detects `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
- Single command, no setup
- Outputs a risk table with scores per dependency

## Links

- npm: https://www.npmjs.com/package/proof-of-commitment
- Web audit: https://getcommit.dev