### PR TITLE
Add lacy — ZSH/Bash plugin that routes natural language to AI agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -801,6 +801,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
 
 ### LLM Interaction
+- [lacy](https://github.com/lacymorrow/lacy) - Shell plugin that routes natural language to AI agents and commands to the shell. Real-time color indicator.
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
 

--- a/readme.md
+++ b/readme.md
@@ -444,6 +444,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [undollar](https://github.com/ImFeelingDucky/undollar) - Strip the '$' preceding copy-pasted terminal commands.
 - [pipe_exec](https://github.com/koraa/pipe_exec) - Run executables from stdin, pipes and ttys without creating a temporary file.
 - [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets.
+- [lacy](https://github.com/lacymorrow/lacy) - ZSH/Bash plugin that routes natural language to your AI agent and commands to your shell — no prefix, no hotkey.
 - [envio](https://github.com/envio-cli/envio) - Manage environment variables securely.
 - [await](https://github.com/slavaGanzin/await) - Runs commands in parallel and waits for their termination.
 - [aha](https://github.com/theZiz/aha) - Convert ANSI output to HTML.


### PR DESCRIPTION
## Add lacy

- **GitHub:** https://github.com/lacymorrow/lacy
- **Category:** Shell Utilities + LLM Interaction

Lacy is a ZSH/Bash plugin that automatically routes natural language to your AI agent (Claude Code, Gemini CLI, OpenCode, etc.) and commands to your shell. No prefix, no hotkey — pure lexical analysis, sub-millisecond, no API calls.

- v1.8.20, 39 releases, actively maintained
- ZSH + Bash 4+, macOS, Linux, WSL
- Works with any AI CLI tool

Added to both **Shell Utilities** and **LLM Interaction** sections.