### PR TITLE
Add ShellSage (AI > LLM Interaction)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -818,6 +818,7 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
+- [ShellSage](https://github.com/AhsanAhmadkiani/ShellSage) - Turns plain English into OS-aware shell commands, running locally via Ollama with safety checks and command memory.
 
 ## Other Resources
 


### PR DESCRIPTION
Adds [ShellSage](https://github.com/AhsanAhmadkiani/ShellSage) under **AI > LLM Interaction**.

ShellSage turns plain English into OS-aware shell commands, running fully locally via Ollama. It detects your OS and package manager, blocks dangerous commands, confirms risky ones, and remembers what works. MIT licensed, with tests and CI.

- [x] Searched previous suggestions before making a new one
- [x] Added entry in alphabetical order within its section
- [x] Description is short and concise, with no redundant words