### PR TITLE
Add sensegrep

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
 - [dotenv-diff](https://github.com/Chrilleweb/dotenv-diff) - Validate environment variable usage in a codebase.
+- [sensegrep](https://github.com/Stahldavid/sensegrep) - Semantic + structural code search; find code by meaning, not just text.
 
 ### Text Editors
 


### PR DESCRIPTION
New App Submission:

marque a caixa [x] I've read the contribution guidelines
Repo or homepage link:

https://github.com/Stahldavid/sensegrep
Description:

Semantic + structural code search CLI — find code by meaning, not just text, using semantic search, exact matching, and AST-aware (tree-sitter) retrieval.
Why I think it's awesome:

Unlike grep/ripgrep, sensegrep searches by meaning and returns whole symbols (functions, classes) aligned to the AST, then collapses irrelevant code. A query like "authentication logic" finds the auth functions even when they don't contain that word. Install with `npm i -g @sensegrep/cli`. Open source, Apache-2.0.
