### PR TITLE
Add linkedin2md to Productivity list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,6 +323,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [CookCLI](https://github.com/cooklang/CookCLI) - Full-featured recipe manager.
 - [hns](https://github.com/primaprashant/hns) - Speech-to-text tool to transcribe voice from microphone.
 - [mynav](https://github.com/GianlucaP106/mynav) - Workspace and session management TUI.
+- [linkedin2md](https://github.com/juanmanueldaza/linkedin2md) - Export LinkedIn data to Markdown + PDF resume.
 
 ### Time Tracking
 


### PR DESCRIPTION
Adds linkedin2md tool for exporting LinkedIn data to Markdown + PDF resume.