### PR TITLE
Add toktrack

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -822,7 +822,6 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
-- [toktrack](https://github.com/mag123c/toktrack) - Tracks token usage and cost across AI coding agents, with a persistent cache that survives session-file deletion.
 
 ## Other Resources
 

--- a/readme.md
+++ b/readme.md
@@ -821,6 +821,7 @@ Inclusion criteria are less strict for this fast-moving field.
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
+- [toktrack](https://github.com/mag123c/toktrack) - Tracks token usage and cost across AI coding agents, with a persistent cache that survives session-file deletion.
 
 ## Other Resources
 

--- a/readme.md
+++ b/readme.md
@@ -817,6 +817,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
 - [hcom](https://github.com/aannoo/hcom) - Orchestration and communication layer for managing multiple agents in their respective TUI apps.
+- [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
#### New App Submission

- [x] I've read the contribution guidelines.

**Repo or homepage link:**
https://github.com/mag123c/toktrack

**Description:**
Tracks token usage and cost across AI coding agents, with a persistent cache that survives session-file deletion.

**Why I think it's awesome:**
It's the only AI usage tracker with a persistent cache that preserves cost history even after a CLI (e.g. Claude Code) deletes its own session logs. Unifies Claude Code, Codex, Gemini, and more in one fast Rust TUI/CLI, installable via npx, Homebrew, or cargo.