### PR TITLE
Add trustcheck

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -492,6 +492,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
 - [andcli](https://github.com/tjblackheart/andcli) - Work with 2FA tokens from multiple OTP providers.
+- [trustcheck](https://github.com/Halfblood-Prince/trustcheck) - Tool for checking Python package trust and supply-chain security signals.
 
 ### Math
 


### PR DESCRIPTION
Add trustcheck.

<!---
Thank you for your pull request.
Please check the contribution guidelines for what is required of the app and this PR.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/Halfblood-Prince/trustcheck

**Description:** Trustcheck is a command-line tool for checking Python package trust and software supply-chain security signals, including package metadata, repository consistency, provenance, vulnerabilities and dependency-related risks.

**Why I think it's awesome:** Trustcheck is useful because it gives developers a quick way to inspect whether a Python package looks trustworthy before adding it to a project. It combines several important supply-chain security checks into a simple CLI workflow, making it easier to spot suspicious metadata, repository mismatches, known vulnerabilities, or risky dependency signals early.