### PR TITLE
Add fort — macOS security audit CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -492,6 +492,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
 - [andcli](https://github.com/tjblackheart/andcli) - Work with 2FA tokens from multiple OTP providers.
+- [fort](https://github.com/djadmin/fort) - Audit and auto-fix macOS security settings. Runs 16 checks, scores your posture, and fixes what it safely can.
 
 ### Math
 


### PR DESCRIPTION
## fort — Audit and auto-fix macOS security settings

**Repository:** https://github.com/djadmin/fort

fort runs 16 security checks on your Mac (FileVault, firewall, SIP, screen lock, SSH, Gatekeeper, etc.), scores your security posture, and auto-fixes what it safely can — all in one command.

- Single static Go binary, no dependencies
- Installable via Homebrew: `brew install djadmin/tap/fort`
- JSON output for scripting/fleet use
- Generates HTML evidence reports (SOC 2 / ISO 27001 mappings)
- Free and open source (MIT)

Added under **Security** section, alphabetically ordered.