### PR TITLE
Add ccline - type a thought at your zsh prompt, get an answer and run commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -821,6 +821,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 
 ### LLM Interaction
+- [ccline](https://github.com/jianshuo/ccline) - Type a thought at your zsh prompt — no command, no prefix — get an answer from Claude or Codex, and run any suggested commands from an interactive menu.
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
 


### PR DESCRIPTION
## What does this add?

[ccline](https://github.com/jianshuo/ccline) — hijacks zsh's `command_not_found_handler` so you can type a natural-language thought directly at your prompt. If the answer contains shell commands, an interactive arrow-key menu lets you confirm and run them.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   find . -type f -size +100M
   ➤ Run all of them
   ✗ Cancel
```

- Uses `claude` CLI (preferred) or `codex` CLI — auto-detected
- One-word inputs (typos) are passed through normally; two-or-more-word inputs go to the LLM
- Markdown rendered with `glow` if installed, otherwise built-in perl renderer
- Selected commands run in the live shell (so `cd`, `export`, etc. persist)

Added under **LLM Interaction** as it fits this fast-moving AI section.