### PR TITLE
Add Octomind - AI agent runtime CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -802,6 +802,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [agentify](https://github.com/koriyoshi2041/agentify) - Transform OpenAPI specs into formats for agents.
 - [actionbook](https://github.com/actionbook/actionbook) - Parallel browser interaction for agents.
 - [lean-ctx](https://github.com/yvgude/lean-ctx) - Token-saving context runtime for agents.
+- [Octomind](https://github.com/Muvon/octomind) - Open-source, model-agnostic AI agent runtime with community tap registry, MCP support with runtime self-extension, 13+ providers, and adaptive compression. Install agents, not frameworks. [octomind.run](https://octomind.run)
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
## Adding Octomind

[Octomind](https://octomind.run) is an open-source, model-agnostic AI agent runtime CLI.

**Why it fits awesome-cli-apps:**
- Terminal-native AI agent runtime — install and run agents from the CLI
- Zero config, single binary (Rust)
- 13+ AI providers out of the box
- Community tap registry for specialist agents (developer:rust, doctor:blood, lawyer:contracts, devops:kubernetes, finance:analyst, security:owasp)
- MCP support with runtime self-extension
- Install via `brew install muvon/tap/octomind`, `cargo install octomind`, or curl

Added under **AI → Agents** section.

---
*Repo: [Muvon/octomind](https://github.com/muvon/octomind) · Website: [octomind.run](https://octomind.run)*