### PR TITLE
Add supercli to Development section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Create pretty HTML from diffs.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
 - [dotenv-diff](https://github.com/Chrilleweb/dotenv-diff) - Validate environment variable usage in a codebase.
+- [supercli](https://github.com/javimosch/supercli) - Universal CLI router with 7,000+ plugins. One command pattern for every tool. JSON-by-default output, agent-native discovery.
 
 ### Text Editors
 


### PR DESCRIPTION
Adds [supercli](https://github.com/javimosch/supercli) — a universal CLI router with 7,000+ plugins. One command pattern (`sc <ns> <res> <action>`) for every tool. JSON-by-default output, agent-native discovery.

This tool fits the Development category as it provides unified access to development tools and workflows.