### PR TITLE
Add imgcli to Image Conversion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -768,6 +768,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [pdfjuicer](https://github.com/dmikhr/pdfjuicer) - Extract PDF pages as images.
 - [gowall](https://github.com/Achno/gowall) - Recolor images, OCR, image upscaling and more.
 - [img2ascii](https://github.com/JosefVesely/Image-to-ASCII) - Convert images to ASCII art.
+- [imgcli](https://github.com/swperb/imgcli) - Tiny dependency-free, ffmpeg-style image convert/resize/crop/filter tool.
 
 ## Screensavers
 


### PR DESCRIPTION
Adds [imgcli](https://github.com/swperb/imgcli) under **Images → Image Conversion**.

A tiny (232 KB), dependency-free, ffmpeg-style CLI to convert, resize, crop, filter, and composite images (PNG/JPEG/BMP/TGA/GIF/PPM). Single self-contained binary, MIT licensed. Fits alongside `imagemagick`/`imgp`/`korkut` in this section.

Follows the existing format (one entry, alphabetically near the other `img*` tools, description starts capitalized and ends with a period).