### PR TITLE
Add gokin to AI > Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -821,6 +821,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [gokin](https://github.com/ginkida/gokin) - Terminal AI coding agent for local Ollama and other providers.
 
 ### LLM Interaction
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.


### PR DESCRIPTION
Adds gokin to the AI > Agents subsection. It is an open-source terminal AI coding agent written in Go (Bubble Tea TUI) that works with local models via Ollama or providers like DeepSeek and Kimi. No telemetry, secrets redacted before they leave the machine. MIT licensed.