### PR TITLE
Add Envkeep to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -492,6 +492,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [hasha-cli](https://github.com/sindresorhus/hasha-cli) - Get the hash of text or stdin.
 - [ots](https://github.com/sniptt-official/ots) - Share secrets with others via a one-time URL.
 - [andcli](https://github.com/tjblackheart/andcli) - Work with 2FA tokens from multiple OTP providers.
+- [Envkeep](https://github.com/jackofshadowz/envkeep) - Encrypted ENV-secret manager that serves one secret at a time to AI coding agents.
 
 ### Math
 


### PR DESCRIPTION
Adds [Envkeep](https://github.com/jackofshadowz/envkeep) to the **Security** section.

Envkeep is an open-source (MIT), zero-dependency, age-encrypted ENV-secret manager. It has a CLI designed for AI coding agents — `envkeep get project/KEY` prints exactly one value on demand — plus a native macOS app. Decrypt-on-demand by default, optional Keychain cache with auto-lock, TOTP 2FA, and project folders.

- Repo: https://github.com/jackofshadowz/envkeep
- License: MIT
- Entry placed in the existing `### Security` section, matching the list format.