### PR TITLE
Add zapdir - Terminal cleanup tool for build artifacts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -618,6 +618,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [rename-cli](https://github.com/jhotmann/node-rename-cli) - Rename files quickly.
 - [renameutils](https://www.nongnu.org/renameutils/) - Mass renaming in your editor.
 - [nomino](https://github.com/yaa110/nomino) - Batch rename utility for developers.
+- [zapdir](https://github.com/Mayne-X/Zapdir) - Blazing-fast terminal cleanup tool for node_modules, .next, dist, and other heavy build artifacts.
 
 ### Disk Usage
 


### PR DESCRIPTION
## Description

Add [zapdir](https://github.com/Mayne-X/Zapdir) to the Deleting, Copying, and Renaming section under Files and Directories.

ZapDir is a blazing-fast terminal cleanup tool that scans for 
ode_modules, .next, dist, uild, and other heavy build artifacts, then lets you selectively delete them with an interactive CLI.

- **Categories:** CLI, Developer Tools, Filesystem, Cleanup
- **Installation:** 
pm install -g zapdir`n- **License:** MIT