### PR TITLE
Add docutrans - AI document translation CLI tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -520,6 +520,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets.
 - [trino](https://github.com/eneserdogan/trino) - Translation of words and phrases.
 - [translate-shell](https://github.com/soimort/translate-shell) - Google Translate interface.
+- [docutrans](https://github.com/lun06318-creator/docutrans) - AI-powered document translation that preserves Markdown formatting.
 
 ### Internet Speedtest
 


### PR DESCRIPTION
## Add docutrans 🚀

**docutrans** is an AI-powered document translation CLI tool that preserves Markdown formatting.

- **Repo**: https://github.com/lun06318-creator/docutrans
- **Install**: `pip install docutrans`
- **Features**: Translates Markdown documents while keeping headings, code blocks, lists, tables, and links intact
- **Configurable**: Works with OpenAI, Azure, or local models via any OpenAI-compatible API

This fits under the Translations section alongside existing translation tools like trino and translate-shell.