### PR TITLE
Add ytstudio-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [editly](https://github.com/mifi/editly) - Declarative video editing.
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A `youtube-dl` fork with additional features and fixes.
 - [cinema](https://github.com/marm00/cinema) - Multiviewer for videos and streams.
+- [ytstudio-cli](https://github.com/jdwit/ytstudio-cli) - Bulk-manage and analyze your YouTube channel (metadata, analytics, comments) from the terminal.
 
 ### Movies
 


### PR DESCRIPTION
Adds [ytstudio-cli](https://github.com/jdwit/ytstudio-cli) to the Video section.

A command-line tool to bulk-manage and analyze a YouTube channel via the official YouTube Data and Analytics APIs: bulk search-replace of titles/descriptions/tags across hundreds of videos, uploads with YAML sidecars, livestream scheduling, comment moderation, analytics queries, and multi-channel profiles. Published on PyPI, MIT-licensed, actively maintained.

Format follows contributing.md (added at the bottom of the Video category).