### PR TITLE
Add git-released (Version Control > Git)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -728,6 +728,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [ggc](https://github.com/bmf-san/ggc) - A modern Git tool with both CLI and interactive incremental-search UI.
 - [AI Git Narrator](https://github.com/pmusolino/AI-Git-Narrator) - [macOS]: Generate commit messages with AI.
 - [gibr](https://github.com/ytreister/gibr) - Easily create consistent git branch names.
+- [git-released](https://github.com/lukaso/released) - Find the first release tag that contains a commit or merged PR.
 
 ### GitHub
 


### PR DESCRIPTION
Adds git-released to Version Control > Git.

git-released finds the first release tag that contains a commit or merged PR/MR, for any public GitHub repo and several GitLab hosts. Published on npm as git-released, MIT-licensed, and maintained. One entry added in the Git section, matching the existing format.