### PR TITLE
Add gh-image

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -736,6 +736,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [CLI GitHub](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
+- [gh-image](https://github.com/drogers0/gh-image) - Upload images to GitHub issues, pull requests, and READMEs.
 
 ### Emoji
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/drogers0/gh-image

**Description:**
A `gh` CLI extension that uploads images straight from the command line, producing GitHub user-attachments URLs suitable for issues, pull requests, and READMEs. Replicates the web UI's internal upload flow; no public API required.

**Why I think it's awesome:**
GitHub provides no public API for image hosting. gh-image reverse-engineers the web UI's upload endpoint as a first-class `gh` extension, so any image can be embedded in Markdown without leaving the terminal. Works with private repos (URLs respect repo visibility), ships prebuilt binaries for macOS/Linux/Windows, and carries ~90% test coverage with SemVer releases.