### PR TITLE
Add sterm to SSH section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -424,6 +424,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 ### SSH
 
 - [mosh](https://mosh.org/) - Remote SSH client that allows roaming with intermittent connectivity.
+- [sterm](https://github.com/ha1377311454/sterm) - Lightweight local SSH connection manager with SFTP, encrypted passwords, and themes (~8 MB, no cloud).
 - [xxh](https://github.com/xxh/xxh) - Bring your favorite shell wherever you go through SSH.
 
 ### Network Utilities


### PR DESCRIPTION
## Summary

Adds [sterm](https://github.com/ha1377311454/sterm) to the **SSH** section.

- Lightweight (~8 MB) local SSH connection manager with dual-pane SFTP
- Encrypted password storage in YAML, no cloud account required
- Runs as a TUI inside your existing terminal (iTerm2, WezTerm, etc.)

## Checklist

- [x] Link is to the official repository
- [x] One-line description follows existing format
- [x] Placed in alphabetical order within SSH section

Made with [Cursor](https://cursor.com)