### PR TITLE
Add sem to Git

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -733,6 +733,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [ggc](https://github.com/bmf-san/ggc) - A modern Git tool with both CLI and interactive incremental-search UI.
 - [AI Git Narrator](https://github.com/pmusolino/AI-Git-Narrator) - [macOS]: Generate commit messages with AI.
 - [gibr](https://github.com/ytreister/gibr) - Easily create consistent git branch names.
+- [sem](https://github.com/Ataraxy-Labs/sem) - Semantic git: function and class level diff, blame, and impact analysis across 32 languages.
 
 ### GitHub
 


### PR DESCRIPTION
Adds [sem](https://github.com/Ataraxy-Labs/sem) to the Git section. sem is a CLI that brings entity-level (function/class/method) diff, blame, and impact analysis to git, across 32 languages via tree-sitter, instead of working line by line.