### PR TITLE
Add RoleCraft to AI/Agents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -827,6 +827,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [RoleCraft](https://github.com/sametcelikbicak/rolecraft) - Zero-dependency CLI to install AI agent skills as roles & behaviors from any source. Works with 30+ coding agents.
 
 ### LLM Interaction
 


### PR DESCRIPTION
Adds [RoleCraft](https://github.com/sametcelikbicak/rolecraft) — a zero-dependency CLI to install AI agent skills as roles & behaviors from any source, compatible with 30+ coding agents.

- **AI > Agents** section