### PR TITLE
Add llm-box to AI Agents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -828,6 +828,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [llm-box](https://github.com/alib8b8/llm-box) - Terminal-based AI workflow engine with YAML-driven pipelines, 20+ LLM providers, and a TUI for workflow management.
 
 ### LLM Interaction
 


### PR DESCRIPTION
## Description

Adding [llm-box](https://github.com/alib8b8/llm-box) - a terminal-based AI workflow engine with YAML-driven pipelines.

## Summary of Changes

- Added llm-box entry to the AI → Agents section

## Why it belongs here

- **Terminal-native**: Built from the ground up for CLI usage with a TUI interface (bubbletea/lipgloss)
- **YAML-driven workflows**: Deterministic, reproducible pipelines with clear step definitions
- **20+ LLM providers**: Supports DeepSeek, Qwen, GLM, Mistral, Kimi, and many more via OpenAI-compatible APIs
- **Local-first**: Runs entirely on your machine, data stays private
- **Single binary**: Written in Go, no dependencies, just download and run
- **MIT licensed**: Fully open source