### PR TITLE
Add 5dive

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
 - [dotenv-diff](https://github.com/Chrilleweb/dotenv-diff) - Validate environment variable usage in a codebase.
 - [ota](https://github.com/ota-run/ota) - Unified diagnosable repo setup across stacks (local, deploy, CI, agents).
+- [5dive](https://github.com/5dive-ai/5dive) - Run a team of AI coding agents (Claude Code, Codex, and more) on a server you own.
 
 ### Text Editors
 


### PR DESCRIPTION
Adds [5dive](https://github.com/5dive-ai/5dive) to Development.

5dive is a self-hosted, MIT-licensed CLI for running a team of AI coding agents (Claude Code, Codex, Grok, and more) on your own server: one-command agent spin-up, cron scheduling, a shared task queue, and Telegram control.

Entry matches the list format. Happy to adjust wording or placement.
