### PR TITLE
Add filecast to file sync/sharing list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -655,7 +655,6 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 
 - [rclone](https://github.com/ncw/rclone) - Sync files with various cloud providers.
 - [ffsend](https://github.com/timvisee/ffsend) - Quick file share.
-- [filecast](https://github.com/gistrec/filecast) - Send a file to every machine on your LAN at once.
 - [share-cli](https://github.com/marionebl/share-cli) - Share files with your local network.
 - [google-drive-upload](https://github.com/labbots/google-drive-upload) - Upload/sync with Google Drive.
 - [gdrive-downloader](https://github.com/Akianonymus/gdrive-downloader) - Download files/folders from Google Drive.
@@ -666,6 +665,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [share](https://github.com/beavailable/share) - Share and receive files effortlessly over HTTP.
 - [shuk](https://shuk.rs) - Quicky share files using Amazon S3 buckets.
 - [croc](https://github.com/schollz/croc) - Easily send things from one computer to another.
+- [filecast](https://github.com/gistrec/filecast) - Fast file transfer to multiple machines on your LAN.
 
 ### Directory Listing
 

--- a/readme.md
+++ b/readme.md
@@ -655,6 +655,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 
 - [rclone](https://github.com/ncw/rclone) - Sync files with various cloud providers.
 - [ffsend](https://github.com/timvisee/ffsend) - Quick file share.
+- [filecast](https://github.com/gistrec/filecast) - Send a file to every machine on your LAN at once.
 - [share-cli](https://github.com/marionebl/share-cli) - Share files with your local network.
 - [google-drive-upload](https://github.com/labbots/google-drive-upload) - Upload/sync with Google Drive.
 - [gdrive-downloader](https://github.com/Akianonymus/gdrive-downloader) - Download files/folders from Google Drive.


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/gistrec/filecast

**Description:**

Fast file transfer over LAN using UDP broadcast, with built-in packet loss recovery. Works on Linux, macOS, and Windows

**Why I think it's awesome:**

Most file-transfer tools are point-to-point: to get a file onto 40 machines you run 40 transfers (or one that fans out and copies the bytes 40 times). `filecast` sends each byte once — over UDP broadcast and every machine on the LAN grabs it in the time of a single transfer