### PR TITLE
Add codex-vitals (AI > Agents)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -829,6 +829,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [codex-vitals](https://github.com/WinningBean/codex-vitals) - Live panel for a Codex CLI session — context %, rate limits, model, and git in a pane below Codex.
 
 ### LLM Interaction
 


### PR DESCRIPTION
Adds [codex-vitals](https://github.com/WinningBean/codex-vitals) to **AI > Agents** — a live terminal panel that sits in a pane below your Codex CLI session, showing context %, 5h/weekly rate limits, model, and git. Single Go binary, one-line install. Similar in spirit to agent-deck / toktrack already listed.