### PR TITLE
Add gitfetch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -742,7 +742,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [cli-github](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
-- [gitfetch](https://github.com/Matars/gitfetch) - Neofetch-style stats for your git profiles.
+- [gitfetch](https://github.com/Matars/gitfetch) - Neofetch-style stats of your git forge.
 
 ### Emoji
 

--- a/readme.md
+++ b/readme.md
@@ -742,6 +742,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [cli-github](https://github.com/IonicaBizau/cli-github) - Fancy GitHub client.
 - [hub](https://github.com/github/hub) - Make git easier to use with GitHub.
 - [git-labelmaker](https://github.com/himynameisdave/git-labelmaker) - Edit GitHub labels.
+- [gitfetch](https://github.com/Matars/gitfetch) - Neofetch-style stats for your git profiles.
 
 ### Emoji
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/Matars/gitfetch

**Description:**
A neofetch-style CLI that displays your GitHub user or repo stats — contributions, stars, repos, PRs, issues, streaks, and more — right in your terminal with customizable color themes.

**Why I think it's awesome:**
It scratches a real itch that nothing else quite fills — there are GitHub stats generators and neofetch clones, but nothing that combines the two in a single, installable binary. One command (even on a repo you don't own) and you get a visual dashboard of contributions, streak data, top languages, and PR activity. The ASCII art shapes (`--shape`) and timeline graphs make it actually fun to run, and the one-liner install means devs are seconds away from using it.
