### PR TITLE
Add pointflow to Terminal Sharing Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -424,6 +424,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gotty](https://github.com/yudai/gotty) - Share your terminal as a web application.
 - [warp](https://github.com/spolu/warp) - Secure and simple terminal sharing.
 - [upterm](https://github.com/owenthereal/upterm) - Instant terminal sharing.
+- [pointflow](https://github.com/supreeth-Finsamudra/pointflow) - View and type into your shells from a phone browser.
 
 ### SSH
 


### PR DESCRIPTION
Adds [pointflow](https://github.com/supreeth-Finsamudra/pointflow) — a single-binary Rust agent that serves your shells to a phone browser as full-color xterm.js terminals (tmux panes on macOS/Linux, ConPTY on Windows), with typing back into any pane. Token-paired via QR; optional Cloudflare quick tunnel for off-LAN use. MIT.

Placed in *Terminal Sharing Utilities* alongside gotty/upterm, matching the line format.

Disclosure: I'm one of the authors. Happy to adjust wording or placement.