### PR TITLE
Add browserbash to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -331,6 +331,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [mynav](https://github.com/GianlucaP106/mynav) - Workspace and session management TUI.
 - [linear-tui](https://github.com/roeyazroel/linear-tui) - Linear TUI client.
 - [jiratui](https://github.com/whyisdifficult/jiratui) - TUI app for Jira.
+- [browserbash](https://github.com/PramodDutta/browserbash) - Run plain-English browser tests through an AI agent in a real browser, with deterministic assertions and CI exit codes.
 
 ### Time Tracking
 


### PR DESCRIPTION
Adds **browserbash** to Development -> Testing.

- Repo: https://github.com/PramodDutta/browserbash (Apache-2.0)
- Install: `npm install -g browserbash-cli`

browserbash is an open-source CLI where an AI agent runs plain-English browser tests in a real Chrome and returns deterministic assertions plus CI exit codes. Runs on free local models, no API keys. Single-line addition following the `- [name](url) - description.` format.