### PR TITLE
Add CodeAlmanac

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -832,6 +832,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [CodeAlmanac](https://github.com/AlmanacCode/codealmanac) - Self-updating repo wiki for AI coding agents.
 
 ### LLM Interaction
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/AlmanacCode/codealmanac

**Description:**

Self-updating repo wiki for AI coding agents.

**Why I think it's awesome:**

CodeAlmanac gives coding agents a local, versioned place to keep project context and decisions without sending that memory to a hosted service. It is useful for teams using agent CLIs because the knowledge lives in the repo and can be reviewed like code.
