### PR TITLE
Add AgentBox to AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -832,6 +832,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [AgentBox](https://github.com/madarco/agentbox) - Run multiple coding agents in parallel, each in its own sandboxed VM (local Docker or cloud), via detachable tmux sessions.
 
 ### LLM Interaction
 


### PR DESCRIPTION
Adds [AgentBox](https://github.com/madarco/agentbox) to **Artificial Intelligence → Agents**, alongside the existing tmux/worktree-based agent session managers (agent-of-empires, agent-deck).

Runs multiple coding agents in parallel, each in its own sandboxed VM (local Docker or cloud), via detachable tmux sessions. MIT, npm `@madarco/agentbox`.