### PR TITLE
Add faf-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -832,6 +832,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [toktrack](https://github.com/mag123c/toktrack) - Track token usage and cost across all agents.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
+- [faf-cli](https://github.com/Wolfe-Jam/faf-cli) - Authors AGENTS.md, CLAUDE.md and .cursorrules AI-Context files from your repo's real stack.
 
 ### LLM Interaction
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/Wolfe-Jam/faf-cli

**Description:** Authors AGENTS.md, CLAUDE.md and .cursorrules AI-Context files from your repo's real stack.

**Why I think it's awesome:**  

.FAF Context exists because I couldn't believe that none of the BIG Companies had written a format for Context, for AI. We have 'package.json' for dependencies, and I found myself using that and README.md to try and give AI, context. I tried many AI's and settled on Claude early-on. Remarkably, Claude agreed that AI needed a format for Context, and even wrote about .FAF, "It's so logical if it never existed AI would have created it itself." -- This was in the Summer of 2025, I have been hooked on solving 'Context for the AI era' ever since. I hope you now understand what project.faf is and why it sits directly in-between, package.json and README.md in repos that use .FAF

```
├── package.json     ← npm reads this
├── project.faf      ← AI reads this
├── README.md        ← humans read this
```
