### PR TITLE
Add BDE Score - stock analysis CLI tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
   - [Agents](#agents)
   - [LLM Interaction](#llm-interaction)
 - [Other Resources](#other-resources)
+- [BDE Score](https://github.com/hbhqq9/bde-score) - Multi-factor stock analysis CLI with US/HK/A-share coverage, shields.io badges, and API access.
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
Add BDE Score to the list.\n\nBDE Score is a command-line stock analysis tool with:\n- Multi-factor scoring (fundamentals, technicals, risk, sentiment)\n- Covers 74 stocks across US/HK/A-share markets\n- shields.io dynamic badges\n- REST API + GitHub Action\n\nCLI Usage:\ncurl https://atlantic-remains-atomic-floor.trycloudflare.com/api/analyze?symbol=AAPL\n\nGitHub: https://github.com/hbhqq9/bde-score