### PR TITLE
Add Foxschema to Database

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [rdsai-cli](https://github.com/aliyun/rdsai-cli) - AI-powered MySQL client.
 - [squix](https://github.com/eduardofuncao/squix) - SQL client with query management and interactive results.
 - [pgxcli](https://github.com/Balaji01-4D/pgxcli) - Feature-complete PostgreSQL client in Go.
+- [Foxschema](https://foxschema.com) - CLI for comparing PostgreSQL and MySQL schemas and generating database migrations.
 
 ### Devops
 


### PR DESCRIPTION
## Summary
- Adds [Foxschema](https://foxschema.com) to the Database section — CLI for comparing PostgreSQL and MySQL schemas and generating database migrations.

## Test plan
- N/A (documentation-only change to readme.md)

Made with [Cursor](https://cursor.com)