### PR TITLE
Add capcut-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [editly](https://github.com/mifi/editly) - Declarative video editing.
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A `youtube-dl` fork with additional features and fixes.
 - [cinema](https://github.com/marm00/cinema) - Multiviewer for videos and streams.
+- [capcut-cli](https://github.com/renezander030/capcut-cli) - Edit CapCut and JianYing projects: subtitles, timing, speed, and cut long-form to shorts.
 
 ### Movies
 

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [editly](https://github.com/mifi/editly) - Declarative video editing.
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A `youtube-dl` fork with additional features and fixes.
 - [cinema](https://github.com/marm00/cinema) - Multiviewer for videos and streams.
-- [capcut-cli](https://github.com/renezander030/capcut-cli) - Edit CapCut and JianYing projects: subtitles, timing, speed, and cut long-form to shorts.
+- [capcut-cli](https://github.com/renezander030/capcut-cli) - Edit CapCut/JianYing projects.
 
 ### Movies
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/renezander030/capcut-cli

**Description:**

Edit CapCut and JianYing projects: subtitles, timing, speed, and cut long-form to shorts.

**Why I think it's awesome:**

I built this because there was no way to script CapCut edits without clicking through the desktop app. It reads the draft JSON directly, so there is no reverse-engineered API and no GUI automation. I use it to batch-cut long recordings into shorts and fix subtitle timing across a lot of clips at once. Open source (MIT), on npm, and I keep it actively maintained.
