### PR TITLE
Add todo-board

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [gtasks](https://github.com/BRO3886/gtasks) - Manage Google Tasks.
 - [epiq](https://github.com/ljtn/epiq) - Local-first distributed issue tracker backed by Git.
 - [feeling](https://github.com/qiz-li/feeling) - Mood tracker that visualizes your emotional patterns over time.
+- [todo-board](https://github.com/kushasahu7/todo-board) - Read-only Kanban board for a Markdown TODO.md file; zero dependencies.
 
 ### Finance
 


### PR DESCRIPTION
Adds [todo-board](https://github.com/kushasahu7/todo-board) under **Note Taking, Lists, Task Management**.

A zero-dependency, read-only Kanban/EPIC board for a Markdown `TODO.md` file — point it at any Markdown file and view it as a board in the browser. MIT licensed.