### PR TITLE
Add ble

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -419,6 +419,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [dark-mode](https://github.com/sindresorhus/dark-mode) - Toggle dark mode.
 - [clippy](https://github.com/neilberkman/clippy) - Clipboard tool for interacting with GUI applications.
 - [anvil](https://github.com/0xjuanma/anvil) - Config management and app installations.
+- [ble](https://github.com/kylebrowning/BLESwiftCLI) - Scan, connect, pair, read, write, and stream Bluetooth LE peripherals.
 
 ### Terminal Sharing Utilities
 


### PR DESCRIPTION
Adds [ble](https://github.com/kylebrowning/BLESwiftCLI) to Utilities → macOS: a Bluetooth Low Energy tool that scans, connects, pairs, reads, writes (structured payloads from YAML/JSON), inspects GATT trees with SIG assigned names, and streams notifications and L2CAP channels.

- Apache 2.0 licensed
- Installable via Homebrew (`brew install kylebrowning/tap/ble`) and Mint
- Documented in the README with per-command examples