### PR TITLE
Add agentty

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -834,6 +834,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
 - [faf-cli](https://github.com/Wolfe-Jam/faf-cli) - Authors AGENTS.md, CLAUDE.md and .cursorrules AI-Context files from your repo's real stack.
+- [agentty](https://github.com/1ay1/agentty) - Native C++26 coding agent; single static binary, millisecond startup, sandboxed by default, any model.
 
 ### LLM Interaction
 

--- a/readme.md
+++ b/readme.md
@@ -834,7 +834,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source agent TUI.
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder) - Local-first agent TUI.
 - [faf-cli](https://github.com/Wolfe-Jam/faf-cli) - Authors AGENTS.md, CLAUDE.md and .cursorrules AI-Context files from your repo's real stack.
-- [agentty](https://github.com/1ay1/agentty) - Native C++26 coding agent; single static binary, millisecond startup, sandboxed by default, any model.
+- [agentty](https://github.com/1ay1/agentty) - C++ agent TUI.
 
 ### LLM Interaction
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/1ay1/agentty  ·  https://agentty.org

**Description:** Native C++26 coding agent; single static binary, millisecond startup, sandboxed by default, any model.

**Why I think it's awesome:** Almost every coding agent in this space is a Node or Python app — agentty is the rare one written in native C++26 that compiles to a single ~13.6 MB static binary with zero runtime dependencies (no Node, Python, or Electron) and cold-starts in under a millisecond, so the TUI never GC-pauses mid-stream. Two things make it stand out from the other Agents entries: every shell/build command it runs is sandboxed by default (Bubblewrap on Linux, `sandbox-exec` on macOS — workspace read-write, system read-only, `~/.ssh` and other projects blocked), and it can drive an agent on an air-gapped host with a single SSH command. It's model-agnostic (Claude Pro/Max OAuth, or OpenAI/Groq/OpenRouter/Ollama), runs inside Zed over ACP, and is MIT-licensed.

Meets the bar: FOSS (MIT), >20 stars, >3 months old, one-line install (`curl -fsSL https://agentty.org/install.sh | sh`), well-documented. Added to the bottom of **AI › Agents** in the required format.