### PR TITLE
Add venv-manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mk](https://github.com/pycontribs/mk) - Exposes most common actions you can run in unfamiliar repos.
 - [dotenv-diff](https://github.com/Chrilleweb/dotenv-diff) - Validate environment variable usage in a codebase.
 - [ota](https://github.com/ota-run/ota) - Unified diagnosable repo setup across stacks (local, deploy, CI, agents).
+- [venv-manager](https://github.com/jacopobonomi/venv_manager) - Manage Python virtual environments with snapshot/rollback, ephemeral sandboxed exec, and an MCP server for AI agents.
 
 ### Text Editors
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/jacopobonomi/venv_manager

**Description:** Manage Python virtual environments with snapshot/rollback, ephemeral sandboxed exec, and an MCP server for AI agents.

**Why I think it's awesome:**

I built this because coding with Claude and Cursor kept leaving my Python setup in a mess — packages installed globally, half-broken venvs, no clean way to roll back after a bad `pip install`. Existing tools handle single project envs well but nothing gave me a fleet view + the safety net I wanted when running AI-generated code.

Concrete things I use daily:

- `snapshot` / `rollback` — capture pip freeze before a risky install, restore in one command. Basically undo for venvs.
- `exec --with pkgs -- cmd` — ephemeral venv à la `uvx`, with `--sandbox` on macOS/Linux so untrusted code can't touch my filesystem or hit the network.
- `watch <file> --venv X` — file watcher that auto-installs missing imports as I (or Claude) edit a script. No more "try to run, get ImportError, install, repeat".
- `mcp` — Model Context Protocol server so Claude Desktop / Cursor / Zed can create, describe, and run inside venvs as native typed tools instead of shell guessing.

Single Go binary, MIT, 35+ stars, active development, tested end-to-end on Ubuntu + macOS via CI.