### PR TITLE
Add kaydet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -365,6 +365,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [gtasks](https://github.com/BRO3886/gtasks) - Manage Google Tasks.
 - [epiq](https://github.com/ljtn/epiq) - Local-first distributed issue tracker backed by Git.
 - [feeling](https://github.com/qiz-li/feeling) - Mood tracker that visualizes your emotional patterns over time.
+- [kaydet](https://github.com/miratcan/kaydet) - Queryable personal database and diary with SQLite search, tags, metadata, and AI integration.
 
 ### Finance
 


### PR DESCRIPTION
Add [kaydet](https://github.com/miratcan/kaydet) - a queryable personal database and terminal diary with SQLite FTS5 search, tags, structured metadata, todo management, and built-in MCP/AI integration.

- Open source (MIT)
- 28+ GitHub stars
- More than 3 years old
- Well documented (README, FILE_FORMAT, QUERY_SYNTAX, etc.)