### PR TITLE
Add emailmd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -492,6 +492,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [gtree](https://github.com/ddddddO/gtree) - Use markdown to generate directory trees and the directories itself.
 - [Jimmy](https://github.com/marph91/jimmy) - Convert various note formats to markdown.
 - [mq](https://github.com/harehare/mq) - Jq-like markdown processor.
+- [emailmd](https://github.com/anypost/emailmd) - Convert markdown into email-safe HTML.
 
 ### Security
 


### PR DESCRIPTION
https://github.com/anypost/emailmd

emailmd converts markdown into email-safe HTML from the command line:

    emailmd input.md -o output.html
    echo "# Hello" | emailmd

Writing email HTML by hand is its own specialty, because mail clients never
agreed on a rendering engine. emailmd takes markdown and emits HTML that holds
up in Outlook, Gmail, Apple Mail and the rest, with `--text` for the plain text
version.

Meets the listed criteria: MIT-licensed, 1.2k stars, first commit February 2026,
installable with `npm install -g emailmd`, documented at
https://www.emailmd.dev/docs.

Disclosure: I maintain emailmd.