### PR TITLE
Add whatbroke to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,7 @@ Expose a service running on localhost to the public web for testing and sharing.
 - [Step CI](https://github.com/stepci/stepci) - API testing and QA framework.
 - [bats-core](https://github.com/bats-core/bats-core) - Bash Automated Testing System.
 - [cmdperf](https://github.com/miklosn/cmdperf) - Quickly benchmark and compare command performance.
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - Diff an AI agent's tool-call behavior between two runs.
 
 ## Productivity
 


### PR DESCRIPTION
Adding whatbroke under Development > Testing.

It's a CLI that diffs an AI agent's recorded behavior between two runs: tool calls, arguments, latency, so you can see what a model swap or prompt change actually broke. Works offline, traces stay local. MIT, on npm as whatbroke-cli.

I'm the author. Followed the existing entry format.
